### PR TITLE
Cherry-pick "Always consider ObservedGeneration for scaling & network types IsReady (#8187)"

### DIFF
--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -50,9 +50,12 @@ func (cs *CertificateStatus) MarkResourceNotOwned(kind, name string) {
 		fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name))
 }
 
-// IsReady returns true is the Certificate is ready.
-func (cs *CertificateStatus) IsReady() bool {
-	return certificateCondSet.Manage(cs).IsHappy()
+// IsReady returns true is the Certificate is ready
+// and the Certificate resource has been observed.
+func (c *Certificate) IsReady() bool {
+	cs := c.Status
+	return cs.ObservedGeneration == c.Generation &&
+		cs.GetCondition(CertificateConditionReady).IsTrue()
 }
 
 // GetCondition gets a specific condition of the Certificate status.

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -62,11 +62,12 @@ func TestCertificateGetGroupVersionKind(t *testing.T) {
 }
 
 func TestMarkReady(t *testing.T) {
-	c := &CertificateStatus{}
-	c.InitializeConditions()
-	apistest.CheckConditionOngoing(c, CertificateConditionReady, t)
+	cs := &CertificateStatus{}
+	cs.InitializeConditions()
+	apistest.CheckConditionOngoing(cs, CertificateConditionReady, t)
 
-	c.MarkReady()
+	cs.MarkReady()
+	c := &Certificate{Status: *cs}
 	if !c.IsReady() {
 		t.Error("IsReady=false, want: true")
 	}
@@ -77,7 +78,7 @@ func TestMarkNotReady(t *testing.T) {
 	c.InitializeConditions()
 	apistest.CheckCondition(c, CertificateConditionReady, corev1.ConditionUnknown)
 
-	c.MarkNotReady("unknow", "unknown")
+	c.MarkNotReady("unknown", "unknown")
 	apistest.CheckCondition(c, CertificateConditionReady, corev1.ConditionUnknown)
 }
 

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -92,8 +92,10 @@ func (is *IngressStatus) MarkIngressNotReady(reason, message string) {
 	ingressCondSet.Manage(is).MarkUnknown(IngressConditionReady, reason, message)
 }
 
-// IsReady looks at the conditions and if the Status has a condition
-// IngressConditionReady returns true if ConditionStatus is True
-func (is *IngressStatus) IsReady() bool {
-	return ingressCondSet.Manage(is).IsHappy()
+// IsReady returns true if the Status condition MetricConditionReady
+// is true and the latest spec has been observed.
+func (i *Ingress) IsReady() bool {
+	is := i.Status
+	return is.ObservedGeneration == i.Generation &&
+		is.GetCondition(IngressConditionReady).IsTrue()
 }

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -107,7 +107,8 @@ func TestIngressTypicalFlow(t *testing.T) {
 	)
 	apistest.CheckConditionSucceeded(r, IngressConditionLoadBalancerReady, t)
 	apistest.CheckConditionSucceeded(r, IngressConditionReady, t)
-	if !r.IsReady() {
+	i := &Ingress{Status: *r}
+	if !i.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 
@@ -118,7 +119,8 @@ func TestIngressTypicalFlow(t *testing.T) {
 	// Mark network configured, and check that ingress is ready again
 	r.MarkNetworkConfigured()
 	apistest.CheckConditionSucceeded(r, IngressConditionReady, t)
-	if !r.IsReady() {
+	i = &Ingress{Status: *r}
+	if !i.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -90,9 +90,12 @@ func (sss *ServerlessServiceStatus) MarkEndpointsNotReady(reason string) {
 		"K8s Service is not ready")
 }
 
-// IsReady returns true if ServerlessService is ready.
-func (sss *ServerlessServiceStatus) IsReady() bool {
-	return serverlessServiceCondSet.Manage(sss).IsHappy()
+// IsReady returns true if the Status condition Ready
+// is true and the latest spec has been observed.
+func (ss *ServerlessService) IsReady() bool {
+	sss := ss.Status
+	return sss.ObservedGeneration == ss.Generation &&
+		sss.GetCondition(ServerlessServiceConditionReady).IsTrue()
 }
 
 // ProxyFor returns how long it has been since Activator was moved

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -78,7 +78,8 @@ func TestSSTypicalFlow(t *testing.T) {
 	apistest.CheckConditionSucceeded(r, ServerlessServiceConditionReady, t)
 
 	// Or another way to check the same condition.
-	if !r.IsReady() {
+	ss := &ServerlessService{Status: *r}
+	if !ss.IsReady() {
 		t.Error("IsReady=false, want: true")
 	}
 	r.MarkEndpointsNotReady("random")

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -73,7 +73,7 @@ func CreateCertificate(t *testing.T, clients *test.Clients, dnsNames []string) (
 // IsCertificateReady will check the status conditions of the certificate and return true if the certificate is
 // ready.
 func IsCertificateReady(c *v1alpha1.Certificate) (bool, error) {
-	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+	return c.IsReady(), nil
 }
 
 // WaitForCertificateSecret polls the status of the Secret for the provided Certificate

--- a/test/ingress.go
+++ b/test/ingress.go
@@ -53,5 +53,5 @@ func WaitForIngressState(client *NetworkingClients, name string, inState func(r 
 // IsIngressReady will check the status conditions of the ingress and return true if the ingress is
 // ready.
 func IsIngressReady(r *v1alpha1.Ingress) (bool, error) {
-	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
+	return r.IsReady(), nil
 }


### PR DESCRIPTION

* Include generation for scaling isready

* Update IsReady for scaling types

* update tests