### PR TITLE
Fix update-codegen.sh when run outside GOPATH

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	k8s.io/apimachinery v0.18.1
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/code-generator v0.18.0
-	knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e
+	knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e
 	knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e
-	knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b
+	knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1386,10 +1386,9 @@ knative.dev/pkg v0.0.0-20200515002500-16d7b963416f/go.mod h1:tMOHGbxtRz8zYFGEGpV
 knative.dev/pkg v0.0.0-20200520073958-94316e20e860/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
 knative.dev/pkg v0.0.0-20200603222317-b79e4a24ca50/go.mod h1:8IfPj/lpuKHHg82xZCl2wuFZ3BM96To72sN1W8T9wjQ=
 knative.dev/pkg v0.0.0-20200611204322-2ddcfef739a2/go.mod h1:rA+FklsrVahwF4a+D63NyHJlzDoAFH81K4J5CYuE3bA=
-knative.dev/pkg v0.0.0-20200619020725-7df8fc5d7743 h1:W1NKMizoXYYX5e2mkFXnn21T7X6ROKKwL8YetGu7xCQ=
-knative.dev/pkg v0.0.0-20200619020725-7df8fc5d7743/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
-knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e h1:fmsw4i/We4S9yyaZadL2z8DKDIz7XzcY/v4yPGUmUA4=
 knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
+knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e h1:MhQNsqYZ5BuDyZT/Q5MQMTMYTmkLcwq6MY+gGvPkymY=
+knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
 knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e h1:I6nRhlOCuFMShAMRhbe9c0+pbfQHttUWZMqVVtRnNt0=
 knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e/go.mod h1:D2ZDLrR9Dq9LiiVN7TatzI7WMcEPgk1MHbbhgBKE6W8=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
@@ -1399,12 +1398,10 @@ knative.dev/test-infra v0.0.0-20200509000045-c7114387eed5/go.mod h1:aMif0KXL4g19
 knative.dev/test-infra v0.0.0-20200513011557-d03429a76034/go.mod h1:aMif0KXL4g19YCYwsy4Ocjjz5xgPlseYV+B95Oo4JGE=
 knative.dev/test-infra v0.0.0-20200519015156-82551620b0a9/go.mod h1:A5b2OAXTOeHT3hHhVQm3dmtbuWvIDP7qzgtqxA3/2pE=
 knative.dev/test-infra v0.0.0-20200522180958-6a0a9b9d893a/go.mod h1:n9eQkzmSNj8BiqNFl1lzoz68D09uMeJfyOjc132Gbik=
-knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974 h1:CrZmlbB+j3ZF/aTrfyypY5ulX2w7XrkfeXKQsbkqzTg=
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
-knative.dev/test-infra v0.0.0-20200617235125-6382dba95484 h1:5D1Fm6aA1T1QQXLb1HkJ5t8gB9pTkhLYak1CCqIP+pE=
 knative.dev/test-infra v0.0.0-20200617235125-6382dba95484/go.mod h1:+BfrTJpc++rH30gX/C0QY6NT2eYVzycll52uw6CrQnc=
-knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b h1:qQTd9xCiV3/PVt2LsmELMVL2gT4eAScMaFrPqiQnt1I=
-knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b/go.mod h1:H8QEB2Y35+vAuVtDbn7QBD+NQr9zQbbxNiovCLNH7F4=
+knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06 h1:6LNkyjc5iPk+Q47wwixmc9CL/0GIL40wZWGlwHXTDRc=
+knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06/go.mod h1:qKM6vO6hD6aa0ZYGDdyr5YiXPQMhbix1K8UWPUvVlIE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
@@ -1425,7 +1422,6 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:w
 sigs.k8s.io/structured-merge-diff/v2 v2.0.1/go.mod h1:Wb7vfKAodbKgf6tn1Kl0VvGj7mRH6DGaRcixXEJXTsE=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
-sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/hack/patches/0001-Patch-to-fix-generate-groups.sh.patch
+++ b/hack/patches/0001-Patch-to-fix-generate-groups.sh.patch
@@ -1,0 +1,40 @@
+From 682f06406c73726775c973f9abc72a0b80a97bad Mon Sep 17 00:00:00 2001
+From: Jon Donovan <jondonovan@google.com>
+Date: Thu, 18 Jun 2020 23:12:55 -0700
+Subject: [PATCH] Patch to fix generate-groups.sh
+
+---
+ vendor/k8s.io/code-generator/generate-groups.sh          | 2 +-
+ vendor/k8s.io/code-generator/generate-internal-groups.sh | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/k8s.io/code-generator/generate-groups.sh b/vendor/k8s.io/code-generator/generate-groups.sh
+index d82002d..e2b694a 100755
+--- a/vendor/k8s.io/code-generator/generate-groups.sh
++++ b/vendor/k8s.io/code-generator/generate-groups.sh
+@@ -50,7 +50,7 @@ shift 4
+   # To support running this script from anywhere, we have to first cd into this directory
+   # so we can install the tools.
+   cd "$(dirname "${0}")"
+-  go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
++  go install "$(pwd -P)"/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+ )
+
+ function codegen::join() { local IFS="$1"; shift; echo "$*"; }
+diff --git a/vendor/k8s.io/code-generator/generate-internal-groups.sh b/vendor/k8s.io/code-generator/generate-internal-groups.sh
+index 8c31d93..ef6bd5b 100755
+--- a/vendor/k8s.io/code-generator/generate-internal-groups.sh
++++ b/vendor/k8s.io/code-generator/generate-internal-groups.sh
+@@ -47,7 +47,8 @@ EXT_APIS_PKG="$4"
+ GROUPS_WITH_VERSIONS="$5"
+ shift 5
+
+-go install ./"$(dirname "${0}")"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
++cd "$(dirname "${0}")"
++go install "$(pwd -P)"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+
+ function codegen::join() { local IFS="$1"; shift; echo "$*"; }
+
+
+2.27.0.278.ge193c7cf3a9-goog
+

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -64,6 +64,8 @@ rm -rf $(find vendor/ -name '*_test.go')
 # Add permission for shell scripts
 chmod +x $(find vendor -name '*.sh')
 
+git apply ./hack/patches/*.patch
+
 
 export GOFLAGS=-mod=vendor
 update_licenses third_party/VENDOR-LICENSE "./..."

--- a/pkg/client/injection/reconciler/networking/v1alpha1/certificate/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/certificate/reconciler.go
@@ -244,9 +244,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 			reconciler.PostProcessReconcile(ctx, resource, original)
 
+<<<<<<< HEAD
 		} else if isROI {
 			// Append the target method to the logger.
 			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+=======
+		reconciler.PostProcessReconcile(ctx, resource, original)
+>>>>>>> 9c436c4... Embed patch for generate-groups from
 
 			// Observe any changes to this resource, since we are not the leader.
 			reconcileEvent = roi.ObserveKind(ctx, resource)

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
@@ -233,9 +233,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 			reconciler.PostProcessReconcile(ctx, resource, original)
 
+<<<<<<< HEAD
 		} else if isROI {
 			// Append the target method to the logger.
 			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+=======
+		reconciler.PostProcessReconcile(ctx, resource, original)
+>>>>>>> 9c436c4... Embed patch for generate-groups from
 
 			// Observe any changes to this resource, since we are not the leader.
 			reconcileEvent = roi.ObserveKind(ctx, resource)

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
@@ -233,9 +233,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 			reconciler.PostProcessReconcile(ctx, resource, original)
 
+<<<<<<< HEAD
 		} else if isROI {
 			// Append the target method to the logger.
 			logger = logger.With(zap.String("targetMethod", "ObserveKind"))
+=======
+		reconciler.PostProcessReconcile(ctx, resource, original)
+>>>>>>> 9c436c4... Embed patch for generate-groups from
 
 			// Observe any changes to this resource, since we are not the leader.
 			reconcileEvent = roi.ObserveKind(ctx, resource)

--- a/vendor/go.opencensus.io/plugin/ochttp/propagation/tracecontext/propagation.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/propagation/tracecontext/propagation.go
@@ -1,0 +1,187 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tracecontext contains HTTP propagator for TraceContext standard.
+// See https://github.com/w3c/distributed-tracing for more information.
+package tracecontext // import "go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"regexp"
+	"strings"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+	"go.opencensus.io/trace/tracestate"
+)
+
+const (
+	supportedVersion  = 0
+	maxVersion        = 254
+	maxTracestateLen  = 512
+	traceparentHeader = "traceparent"
+	tracestateHeader  = "tracestate"
+	trimOWSRegexFmt   = `^[\x09\x20]*(.*[^\x20\x09])[\x09\x20]*$`
+)
+
+var trimOWSRegExp = regexp.MustCompile(trimOWSRegexFmt)
+
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// HTTPFormat implements the TraceContext trace propagation format.
+type HTTPFormat struct{}
+
+// SpanContextFromRequest extracts a span context from incoming requests.
+func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	h, ok := getRequestHeader(req, traceparentHeader, false)
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sections := strings.Split(h, "-")
+	if len(sections) < 4 {
+		return trace.SpanContext{}, false
+	}
+
+	if len(sections[0]) != 2 {
+		return trace.SpanContext{}, false
+	}
+	ver, err := hex.DecodeString(sections[0])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	version := int(ver[0])
+	if version > maxVersion {
+		return trace.SpanContext{}, false
+	}
+
+	if version == 0 && len(sections) != 4 {
+		return trace.SpanContext{}, false
+	}
+
+	if len(sections[1]) != 32 {
+		return trace.SpanContext{}, false
+	}
+	tid, err := hex.DecodeString(sections[1])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	copy(sc.TraceID[:], tid)
+
+	if len(sections[2]) != 16 {
+		return trace.SpanContext{}, false
+	}
+	sid, err := hex.DecodeString(sections[2])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	copy(sc.SpanID[:], sid)
+
+	opts, err := hex.DecodeString(sections[3])
+	if err != nil || len(opts) < 1 {
+		return trace.SpanContext{}, false
+	}
+	sc.TraceOptions = trace.TraceOptions(opts[0])
+
+	// Don't allow all zero trace or span ID.
+	if sc.TraceID == [16]byte{} || sc.SpanID == [8]byte{} {
+		return trace.SpanContext{}, false
+	}
+
+	sc.Tracestate = tracestateFromRequest(req)
+	return sc, true
+}
+
+// getRequestHeader returns a combined header field according to RFC7230 section 3.2.2.
+// If commaSeparated is true, multiple header fields with the same field name using be
+// combined using ",".
+// If no header was found using the given name, "ok" would be false.
+// If more than one headers was found using the given name, while commaSeparated is false,
+// "ok" would be false.
+func getRequestHeader(req *http.Request, name string, commaSeparated bool) (hdr string, ok bool) {
+	v := req.Header[textproto.CanonicalMIMEHeaderKey(name)]
+	switch len(v) {
+	case 0:
+		return "", false
+	case 1:
+		return v[0], true
+	default:
+		return strings.Join(v, ","), commaSeparated
+	}
+}
+
+// TODO(rghetia): return an empty Tracestate when parsing tracestate header encounters an error.
+// Revisit to return additional boolean value to indicate parsing error when following issues
+// are resolved.
+// https://github.com/w3c/distributed-tracing/issues/172
+// https://github.com/w3c/distributed-tracing/issues/175
+func tracestateFromRequest(req *http.Request) *tracestate.Tracestate {
+	h, _ := getRequestHeader(req, tracestateHeader, true)
+	if h == "" {
+		return nil
+	}
+
+	var entries []tracestate.Entry
+	pairs := strings.Split(h, ",")
+	hdrLenWithoutOWS := len(pairs) - 1 // Number of commas
+	for _, pair := range pairs {
+		matches := trimOWSRegExp.FindStringSubmatch(pair)
+		if matches == nil {
+			return nil
+		}
+		pair = matches[1]
+		hdrLenWithoutOWS += len(pair)
+		if hdrLenWithoutOWS > maxTracestateLen {
+			return nil
+		}
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return nil
+		}
+		entries = append(entries, tracestate.Entry{Key: kv[0], Value: kv[1]})
+	}
+	ts, err := tracestate.New(nil, entries...)
+	if err != nil {
+		return nil
+	}
+
+	return ts
+}
+
+func tracestateToRequest(sc trace.SpanContext, req *http.Request) {
+	var pairs = make([]string, 0, len(sc.Tracestate.Entries()))
+	if sc.Tracestate != nil {
+		for _, entry := range sc.Tracestate.Entries() {
+			pairs = append(pairs, strings.Join([]string{entry.Key, entry.Value}, "="))
+		}
+		h := strings.Join(pairs, ",")
+
+		if h != "" && len(h) <= maxTracestateLen {
+			req.Header.Set(tracestateHeader, h)
+		}
+	}
+}
+
+// SpanContextToRequest modifies the given request to include traceparent and tracestate headers.
+func (f *HTTPFormat) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	h := fmt.Sprintf("%x-%x-%x-%x",
+		[]byte{supportedVersion},
+		sc.TraceID[:],
+		sc.SpanID[:],
+		[]byte{byte(sc.TraceOptions)})
+	req.Header.Set(traceparentHeader, h)
+	tracestateToRequest(sc, req)
+}

--- a/vendor/k8s.io/code-generator/generate-groups.sh
+++ b/vendor/k8s.io/code-generator/generate-groups.sh
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, we have to first cd into this directory
   # so we can install the tools.
   cd "$(dirname "${0}")"
-  go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  go install "$(pwd -P)"/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }

--- a/vendor/k8s.io/code-generator/generate-internal-groups.sh
+++ b/vendor/k8s.io/code-generator/generate-internal-groups.sh
@@ -47,7 +47,8 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go install ./"$(dirname "${0}")"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+cd "$(dirname "${0}")"
+go install "$(pwd -P)"/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
 

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
@@ -201,7 +201,7 @@ func isKRShaped(tags map[string]map[string]string) bool {
 	if !has {
 		return false
 	}
-	return vals["krshapedlogic"] == "true"
+	return vals["krshapedlogic"] != "false"
 }
 
 func isNonNamespaced(tags map[string]map[string]string) bool {

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -34,9 +34,9 @@ import (
 	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/zipkin"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 
 	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
 )
 
@@ -135,7 +135,7 @@ func New(
 	// Enable Zipkin tracing
 	roundTripper := &ochttp.Transport{
 		Base:        transport,
-		Propagation: &b3.HTTPFormat{},
+		Propagation: tracecontextb3.TraceContextEgress,
 	}
 
 	sc := SpoofingClient{

--- a/vendor/knative.dev/pkg/tracing/propagation/http_format_sequence.go
+++ b/vendor/knative.dev/pkg/tracing/propagation/http_format_sequence.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package propagation
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// HTTPFormatSequence is a propagation.HTTPFormat that applies multiple other propagation formats.
+// For incoming requests, it will use the first SpanContext it can find, checked in the order of
+// HTTPFormatSequence.Ingress.
+// For outgoing requests, it will apply all the formats to the outgoing request, in the order of
+// HTTPFormatSequence.Egress.
+type HTTPFormatSequence struct {
+	Ingress []propagation.HTTPFormat
+	Egress  []propagation.HTTPFormat
+}
+
+var _ propagation.HTTPFormat = (*HTTPFormatSequence)(nil)
+
+// SpanContextFromRequest satisfies the propagation.HTTPFormat interface.
+func (h *HTTPFormatSequence) SpanContextFromRequest(req *http.Request) (trace.SpanContext, bool) {
+	for _, format := range h.Ingress {
+		if sc, ok := format.SpanContextFromRequest(req); ok {
+			return sc, true
+		}
+	}
+	return trace.SpanContext{}, false
+}
+
+// SpanContextToRequest satisfies the propagation.HTTPFormat interface.
+func (h *HTTPFormatSequence) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	for _, format := range h.Egress {
+		format.SpanContextToRequest(sc, req)
+	}
+}

--- a/vendor/knative.dev/pkg/tracing/propagation/tracecontextb3/http_format.go
+++ b/vendor/knative.dev/pkg/tracing/propagation/tracecontextb3/http_format.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracecontextb3
+
+import (
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	ocpropagation "go.opencensus.io/trace/propagation"
+	"knative.dev/pkg/tracing/propagation"
+)
+
+// TraceContextB3Egress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing
+// formats, preferring TraceContext. It always writes both formats.
+var TraceContextB3Egress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+}
+
+// TraceContextEgress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing
+// formats, preferring TraceContext. It always writes TraceContext format exclusively.
+var TraceContextEgress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+	},
+}
+
+// B3Egress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing formats,
+// preferring TraceContext. It always writes B3 format exclusively.
+var B3Egress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&b3.HTTPFormat{},
+	},
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,6 +188,7 @@ go.opencensus.io/metric/metricproducer
 go.opencensus.io/plugin/ocgrpc
 go.opencensus.io/plugin/ochttp
 go.opencensus.io/plugin/ochttp/propagation/b3
+go.opencensus.io/plugin/ochttp/propagation/tracecontext
 go.opencensus.io/resource
 go.opencensus.io/resource/resourcekeys
 go.opencensus.io/stats
@@ -707,7 +708,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e
+# knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e
 ## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
@@ -754,6 +755,8 @@ knative.dev/pkg/test/logging
 knative.dev/pkg/test/monitoring
 knative.dev/pkg/test/spoof
 knative.dev/pkg/test/zipkin
+knative.dev/pkg/tracing/propagation
+knative.dev/pkg/tracing/propagation/tracecontextb3
 knative.dev/pkg/tracker
 knative.dev/pkg/version
 knative.dev/pkg/webhook
@@ -784,7 +787,7 @@ knative.dev/sample-controller/pkg/client/injection/informers/samples/v1alpha1/ad
 knative.dev/sample-controller/pkg/client/injection/reconciler/samples/v1alpha1/addressableservice
 knative.dev/sample-controller/pkg/client/listers/samples/v1alpha1
 knative.dev/sample-controller/pkg/reconciler/addressableservice
-# knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b
+# knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06
 ## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/yaml v1.2.0


### PR DESCRIPTION
Fix update-codegen.sh after modules migration by hacking generate-groups and generate-internal-groups.

Addresses https://github.com/knative/pkg/issues/1287 if accepted will likely attempt an upstream into library.sh.