### PR TITLE
Removes unwanted timeout setting

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -18,12 +18,8 @@ package v1alpha1
 
 import (
 	"context"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-
-	"knative.dev/networking/pkg/apis/config"
 )
 
 // SetDefaults populates default values in Ingress
@@ -68,12 +64,5 @@ func (p *HTTPIngressPath) SetDefaults(ctx context.Context) {
 	// If only one split is specified, we default to 100.
 	if len(p.Splits) == 1 && p.Splits[0].Percent == 0 {
 		p.Splits[0].Percent = 100
-	}
-
-	cfg := config.FromContextOrDefaults(ctx)
-	maxTimeout := time.Duration(cfg.Defaults.MaxRevisionTimeoutSeconds) * time.Second
-
-	if p.Timeout == nil {
-		p.Timeout = &metav1.Duration{Duration: maxTimeout}
 	}
 }

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -89,8 +89,6 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is filled in.
 								Percent: 100,
 							}},
-							// Timeout and Retries are filled in.
-							Timeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
 						}},
 					},
 				}},
@@ -119,7 +117,6 @@ func TestIngressDefaulting(t *testing.T) {
 								},
 								Percent: 70,
 							}},
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,
@@ -152,8 +149,7 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is kept intact.
 								Percent: 70,
 							}},
-							// Timeout and Retries are kept intact.
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
+							// Retries is kept intact.
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,


### PR DESCRIPTION
Remove setting KIngress timeout per comments from @vagababov and @tcnghia in slack: 
https://knative.slack.com/archives/CA9RHBGJX/p1592591518025100