### PR TITLE
Revert "Removes unwanted timeout setting"

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -18,8 +18,12 @@ package v1alpha1
 
 import (
 	"context"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+
+	"knative.dev/networking/pkg/apis/config"
 )
 
 // SetDefaults populates default values in Ingress
@@ -64,5 +68,12 @@ func (p *HTTPIngressPath) SetDefaults(ctx context.Context) {
 	// If only one split is specified, we default to 100.
 	if len(p.Splits) == 1 && p.Splits[0].Percent == 0 {
 		p.Splits[0].Percent = 100
+	}
+
+	cfg := config.FromContextOrDefaults(ctx)
+	maxTimeout := time.Duration(cfg.Defaults.MaxRevisionTimeoutSeconds) * time.Second
+
+	if p.Timeout == nil {
+		p.Timeout = &metav1.Duration{Duration: maxTimeout}
 	}
 }

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -89,6 +89,8 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is filled in.
 								Percent: 100,
 							}},
+							// Timeout and Retries are filled in.
+							Timeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
 						}},
 					},
 				}},
@@ -117,6 +119,7 @@ func TestIngressDefaulting(t *testing.T) {
 								},
 								Percent: 70,
 							}},
+							Timeout: &metav1.Duration{Duration: 10 * time.Second},
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,
@@ -149,7 +152,8 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is kept intact.
 								Percent: 70,
 							}},
-							// Retries is kept intact.
+							// Timeout and Retries are kept intact.
+							Timeout: &metav1.Duration{Duration: 10 * time.Second},
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,


### PR DESCRIPTION
Reverts knative/networking#22

This is a breaking API change that needs to be tracked as such with the appropriate stakeholders looped in.

/assign @tcnghia @richterdavid 