### PR TITLE
Make use of the class-based genreconciler.

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -25,7 +25,7 @@ import (
 )
 
 // +genclient
-// +genreconciler:krshapedlogic=true
+// +genreconciler:class=networking.knative.dev/ingress.class,krshapedlogic=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
@@ -43,13 +43,16 @@ import (
 const (
 	defaultControllerAgentName = "ingress-controller"
 	defaultFinalizerName       = "ingresses.networking.internal.knative.dev"
+
+	// ClassAnnotationKey points to the annotation for the class of this resource.
+	ClassAnnotationKey = "networking.knative.dev/ingress.class"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // controller.Options to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
+func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -82,6 +85,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		Lister:        lister,
 		reconciler:    r,
 		finalizerName: defaultFinalizerName,
+		classValue:    classValue,
 	}
 
 	t := reflect.TypeOf(r).Elem()


### PR DESCRIPTION
This was originally added in https://github.com/knative/serving/pull/6993, but rolled back
in https://github.com/knative/serving/pull/7050 due to it being a breaking change in close
proximity to the release.

The breakage was niche functionality that was added to facilitate the Openshift migration
from Istio to Kourier as their default kingress, and my VERY FOGGY recollection of the
discussion at the time was that we would roll this back to facilitate that migration, with
the intention of rolling it forwards once we were in the clear.

I don't see any record of the conversation, and searching slack is futile given that this
predates recorded history, so I am going to bias instead towards overkill approvals now.

/hold
/assign @markusthoemmes @tcnghia 