### PR TITLE
Update realm and domain CRD for Kubernetes 1.6

### DIFF
--- a/config/300-domain.yaml
+++ b/config/300-domain.yaml
@@ -25,6 +25,16 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Domain
     plural: domains
@@ -35,5 +45,3 @@ spec:
     shortNames:
     - dom
   scope: Cluster
-  subresources:
-    status: {}

--- a/config/300-realm.yaml
+++ b/config/300-realm.yaml
@@ -25,6 +25,23 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
   names:
     kind: Realm
     plural: realms
@@ -33,12 +50,3 @@ spec:
     - knative-internal
     - networking
   scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"


### PR DESCRIPTION
Since k8s 1.6 changed some fields, this patch updates the CRD accordingly.

Please see: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#other-notable-changes-9

> spec.subresources is removed; use spec.versions[*].subresources instead
> In additionalPrinterColumns items, the JSONPath field was renamed to jsonPath (fixes https://github.com/kubernetes/kubernetes/issues/66531)