### PR TITLE
Add json tags to RealmSpec

### DIFF
--- a/pkg/apis/networking/v1alpha1/realm_types.go
+++ b/pkg/apis/networking/v1alpha1/realm_types.go
@@ -87,13 +87,13 @@ type RealmSpec struct {
 	// originating from outside of the cluster.  Could be omitted for a Realm without
 	// external access.
 	// +optional
-	External string
+	External string `json:"external,omitempty"`
 
-	// Cluster contains the name of the Domain resource corresponding with traffic
+	// Internal contains the name of the Domain resource corresponding with traffic
 	// originating from inside of the cluster.  Could be omitted for a Realm without
 	// internal access.
 	// +optional
-	Cluster string
+	Internal string `json:"internal,omitempty"`
 }
 
 // RealmStatus will reflect Ready=True if the implementation accepts the Realm data

--- a/pkg/apis/networking/v1alpha1/realm_validation.go
+++ b/pkg/apis/networking/v1alpha1/realm_validation.go
@@ -30,8 +30,8 @@ func (r *Realm) Validate(ctx context.Context) *apis.FieldError {
 // Validate inspects and validates RealmSpec object.
 func (spec *RealmSpec) Validate(ctx context.Context) *apis.FieldError {
 	var all *apis.FieldError
-	if spec.External == "" && spec.Cluster == "" {
-		all = all.Also(apis.ErrMissingOneOf("external", "cluster"))
+	if spec.External == "" && spec.Internal == "" {
+		all = all.Also(apis.ErrMissingOneOf("external", "internal"))
 	}
 	return all
 }

--- a/pkg/apis/networking/v1alpha1/realm_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/realm_validation_test.go
@@ -36,14 +36,14 @@ func TestRealmSpecValidation(t *testing.T) {
 			External: "test-ext",
 		},
 	}, {
-		name: "cluster domain is specified",
+		name: "internal domain is specified",
 		rs: RealmSpec{
-			Cluster: "test-cluster",
+			Internal: "test-cluster",
 		},
 	}, {
-		name: "neither cluster nor external domain is specified",
+		name: "neither internal nor external domain is specified",
 		rs:   RealmSpec{},
-		want: apis.ErrMissingOneOf("spec.cluster", "spec.external"),
+		want: apis.ErrMissingOneOf("spec.internal", "spec.external"),
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This patch adds:
- missing json tags
- replaces `realm.spec.cluster` with `realm.spec.internal`.

The `realm.spec.cluster` and `realm.spec.internal` are mixed in the proposal doc https://docs.google.com/document/d/1IT7LUj2p2FtIKA4cQr2qCLdvGsPv8LP4fMv2anY8iaQ/edit#.
I think `cluster` is confusable so choose `internal`.