### PR TITLE
Revert "Revert "Removes unwanted timeout setting (#22)" (#39)"

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -18,12 +18,8 @@ package v1alpha1
 
 import (
 	"context"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-
-	"knative.dev/networking/pkg/apis/config"
 )
 
 // SetDefaults populates default values in Ingress
@@ -68,12 +64,5 @@ func (p *HTTPIngressPath) SetDefaults(ctx context.Context) {
 	// If only one split is specified, we default to 100.
 	if len(p.Splits) == 1 && p.Splits[0].Percent == 0 {
 		p.Splits[0].Percent = 100
-	}
-
-	cfg := config.FromContextOrDefaults(ctx)
-	maxTimeout := time.Duration(cfg.Defaults.MaxRevisionTimeoutSeconds) * time.Second
-
-	if p.Timeout == nil {
-		p.Timeout = &metav1.Duration{Duration: maxTimeout}
 	}
 }

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -89,8 +89,6 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is filled in.
 								Percent: 100,
 							}},
-							// Timeout and Retries are filled in.
-							Timeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
 						}},
 					},
 				}},
@@ -119,7 +117,6 @@ func TestIngressDefaulting(t *testing.T) {
 								},
 								Percent: 70,
 							}},
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,
@@ -152,8 +149,7 @@ func TestIngressDefaulting(t *testing.T) {
 								// Percent is kept intact.
 								Percent: 70,
 							}},
-							// Timeout and Retries are kept intact.
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
+							// Retries is kept intact.
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
 								Attempts:      2,


### PR DESCRIPTION
This reverts commit c2d27c44d14b7b5259ab04de248b9f0e439f9bc9.

Since there are more and more users reporting that the timeout is affecting their gRPC usage, I am going to roll this forward again. This is potentially breaking change, however ingress implementers have been looped in on Slack and bugs (and the empty value was permitted in the API, albeit with unclear meaning).

I will follow up with adding some reasonable conformance testing for the meaning of "no timeout", as well as more documentations.

/assign @vagababov 
