### PR TITLE
Warm the reverse proxy's DNS cache before serving requests.

### DIFF
--- a/pkg/probe_handler.go
+++ b/pkg/probe_handler.go
@@ -48,5 +48,5 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(HashHeaderName, hh)
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Related: https://github.com/knative-sandbox/net-contour/issues/189