### PR TITLE
Introduce new network.knative.dev/visibility for VisibilityLabelKey

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -165,6 +165,12 @@ const (
 	// since the data won't be transferred in chunks less than 4kb, if the
 	// reverse proxy fails to detect streaming (gRPC, e.g.).
 	FlushInterval = 20 * time.Millisecond
+
+	// VisibilityLabelKey is the label to indicate visibility of Route
+	// and KServices.  It can be an annotation too but since users are
+	// already using labels for domain, it probably best to keep this
+	// consistent.
+	VisibilityLabelKey = "network.knative.dev/visibility"
 )
 
 // DomainTemplateValues are the available properties people can choose from


### PR DESCRIPTION
As per discussion https://github.com/knative/serving/pull/8271#issuecomment-644262433, 
this patch introduces `"network.knative.dev/visibility"` for VisibilityLabelKey
in network repo.

/cc @tcnghia @mattmoor 