### PR TITLE
[release-0.17] Randomize the hostnames in TestMultipleHosts. (#76)

### DIFF
--- a/test/conformance/ingress/hosts.go
+++ b/test/conformance/ingress/hosts.go
@@ -42,6 +42,12 @@ func TestMultipleHosts(t *testing.T) {
 		"add.your.interesting.domain.here.io",
 	}
 
+	// Using fixed hostnames can lead to conflicts when -count=N>1
+	// so pseudo-randomize the hostnames to avoid conflicts.
+	for i, host := range hosts {
+		hosts[i] = name + "." + host
+	}
+
 	// Create a simple Ingress over the Service.
 	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{


### PR DESCRIPTION
When the same hostname is used in multiple concurrent invocations of TestMultipleHosts it leads to the kingress records conflicting and tests failing with 404 or other errors.

Fixes: https://github.com/knative-sandbox/net-contour/issues/194