### PR TITLE
Include Get in the UpdateRetry.

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -691,17 +691,17 @@ func CreateIngressReady(t *testing.T, clients *test.Clients, spec v1alpha1.Ingre
 func UpdateIngress(t *testing.T, clients *test.Clients, name string, spec v1alpha1.IngressSpec) {
 	t.Helper()
 
-	ing, err := clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatal("Error getting Ingress:", err)
-	}
-
-	ing.Spec = spec
 	if err := reconciler.RetryUpdateConflicts(func(attempts int) error {
-		_, err := clients.NetworkingClient.Ingresses.Update(ing)
+		ing, err := clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		ing.Spec = spec
+		_, err = clients.NetworkingClient.Ingresses.Update(ing)
 		return err
 	}); err != nil {
-		t.Fatal("Error updating Ingress:", err)
+		t.Fatal("Error fetching and updating Ingress:", err)
 	}
 }
 


### PR DESCRIPTION
This adjusts the update retry around the ingress update in #79 to include the Get.

The original change was to guard against issues updating gke-resource-quotas, but there is a low incidence of conflicts simply updating the kingress itself.

Here's an example from net-contour:

```
=== CONT  TestIngressConformance/5/update
    update.go:88: Error updating Ingress: Operation cannot be fulfilled on ingresses.networking.internal.knative.dev "ingress-conformance-5-update-eghinekn": the object has been modified; please apply your changes to the latest version and try again
```

However, to resolve this, we actually have to refetch the kingress shell we've stuck the desired IngressSpec into otherwise it will just retry until it has exhausted its attempts because the resourceVersion we're sending back is never changed (and this is what the optimistic concurrency keys off of).