### PR TITLE
Adjust the timeout test values a bit.

### DIFF
--- a/test/conformance/ingress/timeout.go
+++ b/test/conformance/ingress/timeout.go
@@ -39,8 +39,8 @@ func TestTimeout(t *testing.T) {
 	// The timeout, and an epsilon value to use as jitter for testing requests
 	// either hit or miss the timeout (without getting so close that we flake).
 	const (
-		timeout = 1 * time.Second
-		epsilon = 100 * time.Millisecond
+		timeout = 5 * time.Second
+		epsilon = 200 * time.Millisecond
 	)
 
 	// Create a simple Ingress over the Service.


### PR DESCRIPTION
I'm [very intermittently](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-sandbox-net-contour-continuous/1294418269393915904) seeing errors like this:

```
    timeout.go:91: Unexpected status code: 504, wanted 200
    timeout.go:91: HTTP/1.1 504 Gateway Timeout
        Content-Length: 24
        Content-Type: text/plain
        Date: Sat, 15 Aug 2020 00:16:19 GMT
        Server: envoy

        upstream request timeout
```

... which implies epsilon is probably a tad small.

This adjustment actually reduces epsilon as a fraction of the request duration while doubling it's absolute value to account for the latency of the hops involved.