### PR TITLE
Prefer t.Cleanup over test.CleanupOnInterrupt and defer cancel.

### DIFF
--- a/test/conformance/ingress/basic.go
+++ b/test/conformance/ingress/basic.go
@@ -30,11 +30,10 @@ func TestBasics(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -51,7 +50,6 @@ func TestBasics(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	RuntimeRequest(t, client, "http://"+name+".example.com")
 }
@@ -62,11 +60,10 @@ func TestBasicsHTTP2(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameH2C)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameH2C)
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -83,7 +80,6 @@ func TestBasicsHTTP2(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
 	if ri == nil {

--- a/test/conformance/ingress/grpc.go
+++ b/test/conformance/ingress/grpc.go
@@ -40,13 +40,12 @@ func TestGRPC(t *testing.T) {
 	clients := test.Setup(t)
 
 	const suffix = "- pong"
-	name, port, cancel := CreateGRPCService(t, clients, suffix)
-	defer cancel()
+	name, port, _ := CreateGRPCService(t, clients, suffix)
 
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -63,7 +62,6 @@ func TestGRPC(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	conn, err := grpc.Dial(
 		domain+":80",
@@ -97,12 +95,10 @@ func TestGRPCSplit(t *testing.T) {
 	clients := test.Setup(t)
 
 	const suffixBlue = "- blue"
-	blueName, bluePort, cancel := CreateGRPCService(t, clients, suffixBlue)
-	defer cancel()
+	blueName, bluePort, _ := CreateGRPCService(t, clients, suffixBlue)
 
 	const suffixGreen = "- green"
-	greenName, greenPort, cancel := CreateGRPCService(t, clients, suffixGreen)
-	defer cancel()
+	greenName, greenPort, _ := CreateGRPCService(t, clients, suffixGreen)
 
 	// The suffixes we expect to see.
 	want := sets.NewString(suffixBlue, suffixGreen)
@@ -110,7 +106,7 @@ func TestGRPCSplit(t *testing.T) {
 	// Create a simple Ingress over the Service.
 	name := test.ObjectNameForTest(t)
 	domain := name + ".example.com"
-	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -135,7 +131,6 @@ func TestGRPCSplit(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	conn, err := grpc.Dial(
 		domain+":80",

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -38,8 +38,7 @@ func TestTagHeaders(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	t.Cleanup(cancel)
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	const (
 		tagName           = "the-tag"
@@ -48,7 +47,7 @@ func TestTagHeaders(t *testing.T) {
 		backendWithoutTag = "no-tag"
 	)
 
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -84,7 +83,6 @@ func TestTagHeaders(t *testing.T) {
 			},
 		}},
 	})
-	t.Cleanup(cancel)
 
 	tests := []struct {
 		Name        string
@@ -138,13 +136,12 @@ func TestPreSplitSetHeaders(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	const headerName = "Foo-Bar-Baz"
 
 	// Create a simple Ingress over the 10 Services.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -164,7 +161,6 @@ func TestPreSplitSetHeaders(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	t.Run("Check without passing header", func(t *testing.T) {
 		ri := RuntimeRequest(t, client, "http://"+name+".example.com")
@@ -207,8 +203,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 	backends := make([]v1alpha1.IngressBackendSplit, 0, splits)
 	names := make(sets.String, splits)
 	for i := 0; i < splits; i++ {
-		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-		defer cancel()
+		name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 		backends = append(backends, v1alpha1.IngressBackendSplit{
 			IngressBackend: v1alpha1.IngressBackend{
 				ServiceName:      name,
@@ -227,7 +222,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 
 	// Create a simple Ingress over the 10 Services.
 	name := test.ObjectNameForTest(t)
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -238,7 +233,6 @@ func TestPostSplitSetHeaders(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	t.Run("Check without passing header", func(t *testing.T) {
 		// Make enough requests that the likelihood of us seeing each variation is high,

--- a/test/conformance/ingress/hosts.go
+++ b/test/conformance/ingress/hosts.go
@@ -30,8 +30,7 @@ func TestMultipleHosts(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// TODO(mattmoor): Once .svc.cluster.local stops being a special case
 	// for Visibility, add it here.
@@ -49,7 +48,7 @@ func TestMultipleHosts(t *testing.T) {
 	}
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      hosts,
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -66,7 +65,6 @@ func TestMultipleHosts(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	for _, host := range hosts {
 		RuntimeRequest(t, client, "http://"+host)

--- a/test/conformance/ingress/path.go
+++ b/test/conformance/ingress/path.go
@@ -35,24 +35,20 @@ func TestPath(t *testing.T) {
 	clients := test.Setup(t)
 
 	// For /foo
-	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	fooName, fooPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// For /bar
-	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	barName, barPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// For /baz
-	bazName, bazPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	bazName, bazPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
 
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -120,7 +116,6 @@ func TestPath(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	tests := map[string]string{
 		"/foo":  fooName,
@@ -149,19 +144,16 @@ func TestPathAndPercentageSplit(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	fooName, fooPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
-	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	barName, barPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
 
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -207,7 +199,6 @@ func TestPathAndPercentageSplit(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	const (
 		total     = 1000

--- a/test/conformance/ingress/percentage.go
+++ b/test/conformance/ingress/percentage.go
@@ -44,8 +44,7 @@ func TestPercentage(t *testing.T) {
 	// give the last route the remainder.
 	percent, total := 1, 0
 	for i := 0; i < 10; i++ {
-		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-		defer cancel()
+		name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 		backends = append(backends, v1alpha1.IngressBackendSplit{
 			IngressBackend: v1alpha1.IngressBackend{
 				ServiceName:      name,
@@ -72,7 +71,7 @@ func TestPercentage(t *testing.T) {
 
 	// Create a simple Ingress over the 10 Services.
 	name := test.ObjectNameForTest(t)
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -83,7 +82,6 @@ func TestPercentage(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.

--- a/test/conformance/ingress/retry.go
+++ b/test/conformance/ingress/retry.go
@@ -34,13 +34,12 @@ func TestRetry(t *testing.T) {
 			t.Parallel()
 			clients := test.Setup(t)
 			// When the period matches, then it shouldn't fail.
-			name, port, cancel := CreateFlakyService(t, clients, i)
-			defer cancel()
+			name, port, _ := CreateFlakyService(t, clients, i)
 
 			domain := name + ".example.com"
 
 			// Create a simple Ingress over the Service.
-			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+			_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{domain},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -58,7 +57,6 @@ func TestRetry(t *testing.T) {
 					},
 				}},
 			})
-			defer cancel()
 
 			for j := 0; j < 5; j++ {
 				resp, err := client.Get("http://" + domain)
@@ -78,13 +76,12 @@ func TestRetry(t *testing.T) {
 			t.Parallel()
 			clients := test.Setup(t)
 			// When the period matches, then it shouldn't fail.
-			name, port, cancel := CreateFlakyService(t, clients, i)
-			defer cancel()
+			name, port, _ := CreateFlakyService(t, clients, i)
 
 			domain := name + ".example.com"
 
 			// Create a simple Ingress over the Service.
-			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+			_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{domain},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -102,7 +99,6 @@ func TestRetry(t *testing.T) {
 					},
 				}},
 			})
-			defer cancel()
 
 			// When the period is one more than the number of attempts (retries+1), then what we should see is:
 			//   500 {count=4}

--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -30,11 +30,10 @@ func TestRewriteHost(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// Create a simple Ingress over the Service.
-	_, _, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, _, _ = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
 			Hosts:      []string{name + ".example.com"},
@@ -51,7 +50,6 @@ func TestRewriteHost(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	hosts := []string{
 		"vanity.ismy.name",
@@ -65,7 +63,7 @@ func TestRewriteHost(t *testing.T) {
 	}
 
 	// Now create a RewriteHost ingress to point a custom Host at the Service
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      hosts,
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -76,7 +74,6 @@ func TestRewriteHost(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	for _, host := range hosts {
 		RuntimeRequest(t, client, host)

--- a/test/conformance/ingress/timeout.go
+++ b/test/conformance/ingress/timeout.go
@@ -33,8 +33,7 @@ func TestTimeout(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateTimeoutService(t, clients)
-	defer cancel()
+	name, port, _ := CreateTimeoutService(t, clients)
 
 	// The timeout, and an epsilon value to use as jitter for testing requests
 	// either hit or miss the timeout (without getting so close that we flake).
@@ -44,7 +43,7 @@ func TestTimeout(t *testing.T) {
 	)
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -62,7 +61,6 @@ func TestTimeout(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	tests := []struct {
 		name         string

--- a/test/conformance/ingress/tls.go
+++ b/test/conformance/ingress/tls.go
@@ -30,15 +30,13 @@ func TestIngressTLS(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	hosts := []string{name + ".example.com"}
 
-	secretName, cancel := CreateTLSSecret(t, clients, hosts)
-	defer cancel()
+	secretName, _ := CreateTLSSecret(t, clients, hosts)
 
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      hosts,
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -60,7 +58,6 @@ func TestIngressTLS(t *testing.T) {
 			SecretNamespace: test.ServingNamespace,
 		}},
 	})
-	defer cancel()
 
 	t.Run("verify HTTP", func(t *testing.T) {
 		RuntimeRequest(t, client, "http://"+name+".example.com")

--- a/test/conformance/ingress/visibility.go
+++ b/test/conformance/ingress/visibility.go
@@ -37,12 +37,11 @@ func TestVisibility(t *testing.T) {
 	clients := test.Setup(t)
 
 	// Create the private backend
-	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	privateServiceName := test.ObjectNameForTest(t)
 	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc.cluster.local"
-	ingress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	ingress, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{privateHostName},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
@@ -59,7 +58,6 @@ func TestVisibility(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	// Ensure the service is not publicly accessible
 	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
@@ -85,13 +83,12 @@ func TestVisibility(t *testing.T) {
 func testProxyToHelloworld(t *testing.T, ingress *v1alpha1.Ingress, clients *test.Clients, name, privateHostName string) {
 
 	loadbalancerAddress := ingress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
-	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
-	defer cancel()
+	proxyName, proxyPort, _ := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 
 	// Using fixed hostnames can lead to conflicts when -count=N>1
 	// so pseudo-randomize the hostnames to avoid conflicts.
 	publicHostName := name + ".publicproxy.example.com"
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{publicHostName},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -108,7 +105,6 @@ func testProxyToHelloworld(t *testing.T, ingress *v1alpha1.Ingress, clients *tes
 			},
 		}},
 	})
-	defer cancel()
 
 	// Ensure the service is accessible from within the cluster.
 	RuntimeRequest(t, client, "http://"+publicHostName)
@@ -128,8 +124,7 @@ func TestVisibilitySplit(t *testing.T) {
 	// give the last route the remainder.
 	percent, total := 1, 0
 	for i := 0; i < 10; i++ {
-		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-		defer cancel()
+		name, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 		backends = append(backends, v1alpha1.IngressBackendSplit{
 			IngressBackend: v1alpha1.IngressBackend{
 				ServiceName:      name,
@@ -158,7 +153,7 @@ func TestVisibilitySplit(t *testing.T) {
 
 	// Create a simple Ingress over the 10 Services.
 	privateHostName := fmt.Sprintf("%s.%s.%s", name, test.ServingNamespace, "svc.cluster.local")
-	localIngress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	localIngress, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{privateHostName},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
@@ -169,17 +164,15 @@ func TestVisibilitySplit(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	// Ensure we can't connect to the private resources
 	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
 
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
-	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
-	defer cancel()
+	proxyName, proxyPort, _ := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 
 	publicHostName := fmt.Sprintf("%s.%s", name, "example.com")
-	_, client, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{publicHostName},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -196,7 +189,6 @@ func TestVisibilitySplit(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.
@@ -250,26 +242,22 @@ func TestVisibilityPath(t *testing.T) {
 	clients := test.Setup(t)
 
 	// For /foo
-	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	fooName, fooPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// For /bar
-	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	barName, barPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// For /baz
-	bazName, bazPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	bazName, bazPort, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
-	mainName, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	mainName, port, _ := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
 
 	name := test.ObjectNameForTest(t)
 	privateHostName := fmt.Sprintf("%s.%s.%s", name, test.ServingNamespace, "svc.cluster.local")
-	localIngress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	localIngress, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{privateHostName},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
@@ -337,7 +325,6 @@ func TestVisibilityPath(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	// Ensure we can't connect to the private resources
 	for _, path := range []string{"", "/foo", "/bar", "/baz"} {
@@ -345,11 +332,10 @@ func TestVisibilityPath(t *testing.T) {
 	}
 
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
-	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
-	defer cancel()
+	proxyName, proxyPort, _ := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 
 	publicHostName := fmt.Sprintf("%s.%s", name, "example.com")
-	_, client, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{publicHostName},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -366,7 +352,6 @@ func TestVisibilityPath(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	tests := map[string]string{
 		"/foo":  fooName,

--- a/test/conformance/ingress/websocket.go
+++ b/test/conformance/ingress/websocket.go
@@ -39,13 +39,12 @@ func TestWebsocket(t *testing.T) {
 	clients := test.Setup(t)
 
 	const suffix = "- pong"
-	name, port, cancel := CreateWebsocketService(t, clients, suffix)
-	defer cancel()
+	name, port, _ := CreateWebsocketService(t, clients, suffix)
 
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -62,7 +61,6 @@ func TestWebsocket(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	dialer := websocket.Dialer{
 		NetDialContext:   dialCtx,
@@ -88,12 +86,10 @@ func TestWebsocketSplit(t *testing.T) {
 	clients := test.Setup(t)
 
 	const suffixBlue = "- blue"
-	blueName, bluePort, cancel := CreateWebsocketService(t, clients, suffixBlue)
-	defer cancel()
+	blueName, bluePort, _ := CreateWebsocketService(t, clients, suffixBlue)
 
 	const suffixGreen = "- green"
-	greenName, greenPort, cancel := CreateWebsocketService(t, clients, suffixGreen)
-	defer cancel()
+	greenName, greenPort, _ := CreateWebsocketService(t, clients, suffixGreen)
 
 	// The suffixes we expect to see.
 	want := sets.NewString(suffixBlue, suffixGreen)
@@ -101,7 +97,7 @@ func TestWebsocketSplit(t *testing.T) {
 	// Create a simple Ingress over the Service.
 	name := test.ObjectNameForTest(t)
 	domain := name + ".example.com"
-	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -126,7 +122,6 @@ func TestWebsocketSplit(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	dialer := websocket.Dialer{
 		NetDialContext:   dialCtx,


### PR DESCRIPTION
This mostly shifts the kingress conformance tests to use t.Cleanup.  We still
return `context.CancelFunc` to cleanup resources so that tests like TestUpdate
can choose to eagerly clean up resources before the entire test is complete.