### PR TITLE
Enable kingress composition.

### DIFF
--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -131,7 +131,9 @@ func TestInsertProbe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			before := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
+			beforePaths := len(test.ingress.Spec.Rules[0].HTTP.Paths)
+			beforeAppHdr := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
+			beforeMtchHdr := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].Headers)
 			got, err := InsertProbe(test.ingress)
 			if err != nil {
 				t.Errorf("InsertProbe() = %v", err)
@@ -139,9 +141,30 @@ func TestInsertProbe(t *testing.T) {
 			if got != test.want {
 				t.Errorf("InsertProbe() = %s, wanted %s", got, test.want)
 			}
-			after := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
-			if before+1 != after {
-				t.Errorf("InsertProbe() left %d headers, wanted %d", after, before+1)
+
+			afterPaths := len(test.ingress.Spec.Rules[0].HTTP.Paths)
+			if beforePaths+beforePaths != afterPaths {
+				t.Errorf("InsertProbe() %d paths, wanted %d", afterPaths, beforePaths+beforePaths)
+			}
+
+			// Check the matches at the beginning.
+			afterAppHdr := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].AppendHeaders)
+			if beforeAppHdr+1 != afterAppHdr {
+				t.Errorf("InsertProbe() left %d headers, wanted %d", afterAppHdr, beforeAppHdr+1)
+			}
+			afterMtchHdr := len(test.ingress.Spec.Rules[0].HTTP.Paths[0].Headers)
+			if beforeMtchHdr+1 != afterMtchHdr {
+				t.Errorf("InsertProbe() left %d header matches, wanted %d", afterMtchHdr, beforeMtchHdr+1)
+			}
+
+			// Check the matches at the end
+			afterAppHdr = len(test.ingress.Spec.Rules[0].HTTP.Paths[afterPaths-1].AppendHeaders)
+			if beforeAppHdr != afterAppHdr {
+				t.Errorf("InsertProbe() left %d headers, wanted %d", afterAppHdr, beforeAppHdr)
+			}
+			afterMtchHdr = len(test.ingress.Spec.Rules[0].HTTP.Paths[afterPaths-1].Headers)
+			if beforeMtchHdr != afterMtchHdr {
+				t.Errorf("InsertProbe() left %d header matches, wanted %d", afterMtchHdr, beforeMtchHdr)
 			}
 		})
 	}

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -53,6 +53,10 @@ const (
 	// uses to find out which version of the networking config is deployed.
 	HashHeaderName = "K-Network-Hash"
 
+	// HashHeaderValue is the value that must appear in the HashHeaderName
+	// header in order for our network hash to be injected.
+	HashHeaderValue = "override"
+
 	// OriginalHostHeader is used to avoid Istio host based routing rules
 	// in Activator.
 	// The header contains the original Host value that can be rewritten

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -380,6 +380,7 @@ func (m *Prober) processWorkItem() bool {
 		probeURL.String(),
 		prober.WithHeader(network.UserAgentKey, network.IngressReadinessUserAgent),
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
+		prober.WithHeader(network.HashHeaderName, network.HashHeaderValue),
 		m.probeVerifier(item))
 
 	// In case of cancellation, drop the work item

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -63,7 +63,7 @@ func TestProbeAllHosts(t *testing.T) {
 
 	ing := ingTemplate.DeepCopy()
 	ing.Spec.Rules[0].Hosts = append(ing.Spec.Rules[0].Hosts, hostB)
-	hash, err := ingress.InsertProbe(ing)
+	hash, err := ingress.InsertProbe(ing.DeepCopy())
 	if err != nil {
 		t.Fatal("Failed to insert probe:", err)
 	}
@@ -166,13 +166,17 @@ func TestProbeAllHosts(t *testing.T) {
 		}
 	}()
 
-	// Wait for the probing to eventually succeed
-	<-ready
+	select {
+	case <-ready:
+		// Wait for the probing to eventually succeed
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 }
 
 func TestProbeLifecycle(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
-	hash, err := ingress.InsertProbe(ing)
+	hash, err := ingress.InsertProbe(ing.DeepCopy())
 	if err != nil {
 		t.Fatal("Failed to insert probe:", err)
 	}
@@ -261,8 +265,12 @@ func TestProbeLifecycle(t *testing.T) {
 		}
 	}
 
-	// Wait for the probing to eventually succeed
-	<-ready
+	select {
+	case <-ready:
+		// Wait for the probing to eventually succeed
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 
 	// The subsequent calls to IsReady must succeed and return true
 	for i := 0; i < 5; i++ {
@@ -299,8 +307,12 @@ func TestProbeLifecycle(t *testing.T) {
 	// Wait for the first request (success) to be executed
 	<-probeRequests
 
-	// Wait for the probing to eventually succeed
-	<-ready
+	select {
+	case <-ready:
+		// Wait for the probing to eventually succeed
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 
 	select {
 	// Validate that no requests went through the probe handler
@@ -397,8 +409,12 @@ func TestCancelPodProbing(t *testing.T) {
 		t.Fatal("IsReady() returned true")
 	}
 
-	// Wait for the first probe request
-	<-requests
+	select {
+	case <-requests:
+		// Wait for the first probe request
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 
 	// Create a new version of the Ingress (to replace the original Ingress)
 	const otherDomain = "blabla.net"
@@ -466,7 +482,7 @@ func TestCancelPodProbing(t *testing.T) {
 
 func TestPartialPodCancellation(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
-	hash, err := ingress.InsertProbe(ing)
+	hash, err := ingress.InsertProbe(ing.DeepCopy())
 	if err != nil {
 		t.Fatal("Failed to insert probe:", err)
 	}
@@ -535,8 +551,12 @@ func TestPartialPodCancellation(t *testing.T) {
 		t.Fatal("IsReady() returned true")
 	}
 
-	// Wait for the first probe request
-	<-requests
+	select {
+	case <-requests:
+		// Wait for the first probe request
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 
 	// Check that probing is unsuccessful
 	select {
@@ -605,8 +625,12 @@ func TestCancelIngressProbing(t *testing.T) {
 		t.Fatal("IsReady() returned true")
 	}
 
-	// Wait for the first probe request
-	<-requests
+	select {
+	case <-requests:
+		// Wait for the first probe request
+	case <-time.After(5 * time.Second):
+		t.Error("Timed out waiting for probing to succeed.")
+	}
 
 	const domain = "blabla.net"
 


### PR DESCRIPTION
This adjusts the shared probing logic such that kingress resources will properly compose to implement our dataplane contract.  Today the services referenced from kingress are expected to respond to `K-Network-Probe: probe` and `K-Network-Hash: deadbeef` with the network hash they received.  However, the problem we had with composition was that this header was injected unconditionally, so the kingress itself couldn't implement the dataplane contract.

Our new logic leverages header matching to overwrite the network hash only when `K-Network-Hash: override` is specified, which enables us to probe the kingress directly, but avoid overriding values for this, which might come from probing an outer layer.

This makes the implementation of our dataplane contract a simple induction, where the base case is implemented by the service referenced by the kingress and the inductive step is implemented by the conditional header injection.

Fixes https://github.com/knative/serving/issues/9074

As part of this I also made our tests not hand indefinitely as a failure mode, but timeout after some modest duration.

/hold

I'm placing a hold on this, as it will likely require updated to downstream unit tests (I know net-contour needed some).  I'll remove the hold once I've gotten some eyeballs on the staged PRs, but this is RFAL now.