### PR TITLE
Remove Istio specific constants (to be moved to net-istio).

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -84,11 +84,6 @@ const (
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
-
-	// KnativeIngressGateway is the name of the ingress gateway
-	KnativeIngressGateway = "knative-ingress-gateway"
-	// ClusterLocalGateway is the name of the local gateway
-	ClusterLocalGateway = "cluster-local-gateway"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services


### PR DESCRIPTION
Move Istio stuff to `net-istio`.
Unless I missed a repository, this is only used in `net-istio`.

Wait for corresponding `net-istio` PR.
/hold
/assign @tcnghia 