### PR TITLE
Clean up obsolete includeOutboundIPRanges in config-network

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -18,7 +18,6 @@ package pkg
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -31,7 +30,6 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	corev1 "k8s.io/api/core/v1"
 	cm "knative.dev/pkg/configmap"
-	"knative.dev/pkg/logging"
 )
 
 const (
@@ -62,12 +60,6 @@ const (
 	// ConfigName is the name of the configmap containing all
 	// customizations for networking features.
 	ConfigName = "config-network"
-
-	// IstioOutboundIPRangesKey is the name of the configuration entry
-	// that specifies Istio outbound ip ranges.
-	//
-	// DEPRECATED: This will be completely removed in the future release.
-	IstioOutboundIPRangesKey = "istio.sidecar.includeOutboundIPRanges"
 
 	// DeprecatedDefaultIngressClassKey  Please use DefaultIngressClassKey instead.
 	DeprecatedDefaultIngressClassKey = "clusteringress.class"
@@ -268,12 +260,6 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 // NewConfigFromMap creates a Config from the supplied data.
 func NewConfigFromMap(data map[string]string) (*Config, error) {
 	nc := defaultConfig()
-	if _, ok := data[IstioOutboundIPRangesKey]; ok {
-		// TODO(0.15): Until the next version is released, the validation check is
-		// enabled to notify users who configure this value.
-		logger := logging.FromContext(context.Background()).Named("config-network")
-		logger.Warnf("%q is deprecated as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
-	}
 
 	if err := cm.Parse(data,
 		cm.AsString(DeprecatedDefaultIngressClassKey, &nc.DefaultIngressClass),

--- a/pkg/testdata/config-network.yaml
+++ b/pkg/testdata/config-network.yaml
@@ -38,13 +38,6 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # DEPRECATED:
-    # istio.sidecar.includeOutboundIPRanges is obsolete.
-    # The current versions have outbound network access enabled by default.
-    # If you need this option for some reason, please use global.proxy.includeIPRanges in Istio.
-    #
-    # istio.sidecar.includeOutboundIPRanges: "*"
-
     # ingress.class specifies the default ingress class
     # to use when not dictated by Route annotation.
     #

--- a/pkg/testdata/config-network.yaml
+++ b/pkg/testdata/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "b22469ec"
+    knative.dev/example-checksum: "3317ccca"
 data:
   _example: |
     ################################


### PR DESCRIPTION
This patch completely cleans up includeOutboundIPRanges configs.
The next release 0.18 will be 9months since it was obsoleted so we can
remove it.

Fixes https://github.com/knative/serving/issues/6543