### PR TITLE
Add constant for label to disable AutoTLS

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -81,6 +81,10 @@ const (
 	// a wildcard certificate should be not created for it.
 	DisableWildcardCertLabelKey = "networking.knative.dev/disableWildcardCert"
 
+	// DisableAutoTLSLabelKey is the label key attached to a namespace to indicate that
+	// AutoTLS should not be enabled for it.
+	DisableAutoTLSLabelKey = "networking.knative.dev/disableAutoTLS"
+
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"


### PR DESCRIPTION
Add constant for a label to disable AutoTLS in a particular route.

Part of the work for knative/serving#8567