### PR TITLE
Change visibility label to networking.knative.dev from network.knative.dev

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -166,7 +166,7 @@ const (
 	// and KServices.  It can be an annotation too but since users are
 	// already using labels for domain, it probably best to keep this
 	// consistent.
-	VisibilityLabelKey = "network.knative.dev/visibility"
+	VisibilityLabelKey = "networking.knative.dev/visibility"
 )
 
 // DomainTemplateValues are the available properties people can choose from


### PR DESCRIPTION
Since `networking.knative.dev` is used consistently. This patch
changes to `networking.knative.dev` for the label.

Please refer to https://github.com/knative/serving/pull/9013#issuecomment-682148423 as well.

/cc @ZhiminXiang @mattmoor @tcnghia 