### PR TITLE
Make ingress.spec.visibility deprecated

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -35,9 +35,9 @@ func (s *IngressSpec) SetDefaults(ctx context.Context) {
 	for i := range s.Rules {
 		s.Rules[i].SetDefaults(ctx)
 	}
-	if s.Visibility == "" {
-		s.Visibility = IngressVisibilityExternalIP
-	}
+
+	// Deprecated, do not use.
+	s.DeprecatedVisibility = ""
 }
 
 // SetDefaults populates default values in IngressTLS
@@ -49,6 +49,9 @@ func (t *IngressTLS) SetDefaults(ctx context.Context) {
 
 // SetDefaults populates default values in IngressRule
 func (r *IngressRule) SetDefaults(ctx context.Context) {
+	if r.Visibility == "" {
+		r.Visibility = IngressVisibilityExternalIP
+	}
 	r.HTTP.SetDefaults(ctx)
 }
 

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -38,24 +38,10 @@ func TestIngressDefaulting(t *testing.T) {
 		name: "empty",
 		in:   &Ingress{},
 		want: &Ingress{
-			Spec: IngressSpec{
-				Visibility: IngressVisibilityExternalIP,
-			},
+			Spec: IngressSpec{},
 		},
 	}, {
-		name: "has-visibility",
-		in: &Ingress{
-			Spec: IngressSpec{
-				Visibility: IngressVisibilityClusterLocal,
-			},
-		},
-		want: &Ingress{
-			Spec: IngressSpec{
-				Visibility: IngressVisibilityClusterLocal,
-			},
-		},
-	}, {
-		name: "split-timeout-defaulting",
+		name: "split-timeout-and-visibility-defaulting",
 		in: &Ingress{
 			Spec: IngressSpec{
 				Rules: []IngressRule{{
@@ -71,12 +57,12 @@ func TestIngressDefaulting(t *testing.T) {
 						}},
 					},
 				}},
-				Visibility: IngressVisibilityExternalIP,
 			},
 		},
 		want: &Ingress{
 			Spec: IngressSpec{
 				Rules: []IngressRule{{
+					Visibility: IngressVisibilityExternalIP,
 					HTTP: &HTTPIngressRuleValue{
 						Paths: []HTTPIngressPath{{
 							Splits: []IngressBackendSplit{{
@@ -91,14 +77,14 @@ func TestIngressDefaulting(t *testing.T) {
 						}},
 					},
 				}},
-				Visibility: IngressVisibilityExternalIP,
 			},
 		},
 	}, {
-		name: "split-timeout-not-defaulting",
+		name: "split-timeout-and-visibility-defaulting",
 		in: &Ingress{
 			Spec: IngressSpec{
 				Rules: []IngressRule{{
+					Visibility: IngressVisibilityClusterLocal,
 					HTTP: &HTTPIngressRuleValue{
 						Paths: []HTTPIngressPath{{
 							Splits: []IngressBackendSplit{{
@@ -119,12 +105,12 @@ func TestIngressDefaulting(t *testing.T) {
 						}},
 					},
 				}},
-				Visibility: IngressVisibilityExternalIP,
 			},
 		},
 		want: &Ingress{
 			Spec: IngressSpec{
 				Rules: []IngressRule{{
+					Visibility: IngressVisibilityClusterLocal,
 					HTTP: &HTTPIngressRuleValue{
 						Paths: []HTTPIngressPath{{
 							Splits: []IngressBackendSplit{{
@@ -147,7 +133,6 @@ func TestIngressDefaulting(t *testing.T) {
 						}},
 					},
 				}},
-				Visibility: IngressVisibilityExternalIP,
 			},
 		},
 	}}

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -38,11 +38,6 @@ func (i *Ingress) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Ingress")
 }
 
-// IsPublic returns whether the Ingress should be exposed publicly.
-func (i *Ingress) IsPublic() bool {
-	return i.Spec.Visibility == "" || i.Spec.Visibility == IngressVisibilityExternalIP
-}
-
 // GetCondition returns the current condition of a given condition type
 func (is *IngressStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return ingressCondSet.Manage(is).GetCondition(t)

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -61,24 +61,6 @@ func TestIngressGetGroupVersionKind(t *testing.T) {
 	}
 }
 
-func TestIngressIsPublic(t *testing.T) {
-	ci := Ingress{}
-	if !ci.IsPublic() {
-		t.Error("Expected default Ingress to be public, for backward compatibility")
-	}
-	if !ci.IsPublic() {
-		t.Errorf("Expected IsPublic()==true, saw %v", ci.IsPublic())
-	}
-	ci.Spec.Visibility = IngressVisibilityExternalIP
-	if !ci.IsPublic() {
-		t.Errorf("Expected IsPublic()==true, saw %v", ci.IsPublic())
-	}
-	ci.Spec.Visibility = IngressVisibilityClusterLocal
-	if ci.IsPublic() {
-		t.Errorf("Expected IsPublic()==false, saw %v", ci.IsPublic())
-	}
-}
-
 func TestIngressTypicalFlow(t *testing.T) {
 	r := &IngressStatus{}
 	r.InitializeConditions()

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -111,8 +111,13 @@ type IngressSpec struct {
 	// +optional
 	Rules []IngressRule `json:"rules,omitempty"`
 
-	// Visibility setting.
-	Visibility IngressVisibility `json:"visibility,omitempty"`
+	// DeprecatedVisibility was used for the fallback when spec.rules.visibility
+	// isn't set.
+	//
+	// Now spec.rules.visibility is not optional and so we make this field deprecated.
+	//
+	// +optional
+	DeprecatedVisibility IngressVisibility `json:"visibility,omitempty"`
 }
 
 // IngressVisibility describes whether the Ingress should be exposed to
@@ -176,7 +181,6 @@ type IngressRule struct {
 
 	// Visibility signifies whether this rule should `ClusterLocal`. If it's not
 	// specified then it defaults to `ExternalIP`.
-	// +optional
 	Visibility IngressVisibility `json:"visibility,omitempty"`
 
 	// HTTP represents a rule to apply against incoming requests. If the


### PR DESCRIPTION
`ingress.spec.visibility` was used for a fallback when
`spec.rules.visibility` isn't set. But it is not used anymore
actually as route controller always set it.

https://github.com/knative/serving/blob/4c2ae6597b07c8ac05a9731e647d60164940a95e/pkg/reconciler/route/resources/ingress.go#L223

Hence this patch changes to:
- make `ingress.spec.visibility` deprecated.
- drop `+optional` from `spec.rules.visibility`.
- set default to `spec.rules.visibility` for sure.

Co-authored-by: Lvjiawei <lvjiawei@cmss.chinamobile.com>

/cc @tcnghia @mattmoor @ZhiminXiang 