### PR TITLE
Deprecate ingress.status.LoadBalancer status field

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -46,6 +46,9 @@ func (is *IngressStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 // InitializeConditions initializes conditions of an IngressStatus
 func (is *IngressStatus) InitializeConditions() {
 	ingressCondSet.Manage(is).InitializeConditions()
+
+	// Deprecatd, do not set.
+	is.DeprecatedLoadBalancer = nil
 }
 
 // MarkNetworkConfigured set IngressConditionNetworkConfigured in IngressStatus as true
@@ -62,8 +65,7 @@ func (is *IngressStatus) MarkResourceNotOwned(kind, name string) {
 
 // MarkLoadBalancerReady marks the Ingress with IngressConditionLoadBalancerReady,
 // and also populate the address of the load balancer.
-func (is *IngressStatus) MarkLoadBalancerReady(lbs []LoadBalancerIngressStatus, publicLbs []LoadBalancerIngressStatus, privateLbs []LoadBalancerIngressStatus) {
-	is.LoadBalancer = &LoadBalancerStatus{Ingress: lbs}
+func (is *IngressStatus) MarkLoadBalancerReady(publicLbs []LoadBalancerIngressStatus, privateLbs []LoadBalancerIngressStatus) {
 	is.PublicLoadBalancer = &LoadBalancerStatus{Ingress: publicLbs}
 	is.PrivateLoadBalancer = &LoadBalancerStatus{Ingress: privateLbs}
 

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -84,7 +84,6 @@ func TestIngressTypicalFlow(t *testing.T) {
 	// Then ingress has address.
 	r.MarkLoadBalancerReady(
 		[]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}},
-		[]LoadBalancerIngressStatus{{DomainInternal: "gateway.default.svc"}},
 		[]LoadBalancerIngressStatus{{DomainInternal: "private.gateway.default.svc"}},
 	)
 	apistest.CheckConditionSucceeded(r, IngressConditionLoadBalancerReady, t)

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -301,10 +301,10 @@ type HTTPRetry struct {
 type IngressStatus struct {
 	duckv1.Status `json:",inline"`
 
-	// LoadBalancer contains the current status of the load-balancer.
-	// This is to be superseded by the combination of `PublicLoadBalancer` and `PrivateLoadBalancer`
+	// DeprecatedLoadBalancer contains the current status of the load-balancer.
+	// DEPRECATED: Use `PublicLoadBalancer` and `PrivateLoadBalancer` instead.
 	// +optional
-	LoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
+	DeprecatedLoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
 
 	// PublicLoadBalancer contains the current status of the load-balancer.
 	// +optional

--- a/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
@@ -547,8 +547,8 @@ func (in *IngressSpec) DeepCopy() *IngressSpec {
 func (in *IngressStatus) DeepCopyInto(out *IngressStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.LoadBalancer != nil {
-		in, out := &in.LoadBalancer, &out.LoadBalancer
+	if in.DeprecatedLoadBalancer != nil {
+		in, out := &in.DeprecatedLoadBalancer, &out.DeprecatedLoadBalancer
 		*out = new(LoadBalancerStatus)
 		(*in).DeepCopyInto(*out)
 	}


### PR DESCRIPTION
This patch deprecates ingress.status.LoadBalancer. Use
`PublicLoadBalancer` and `PrivateLoadBalancer` instead.

Fixes https://github.com/knative/networking/issues/136