### PR TITLE
Fix an issue with the new test.

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -639,6 +639,7 @@ func CreateIngress(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpe
 		Spec: spec,
 	}
 
+	ing.SetDefaults(context.Background())
 	if err := ing.Validate(context.Background()); err != nil {
 		t.Fatal("Invalid ingress:", err)
 	}


### PR DESCRIPTION
In #138 we added a test that checks the probe semantics of kingress, but this makes the bad assumption that the defaulting webhook is running, which gives the test and the controller consistent views of the resource when computing the probe hash.  The test sees what is committed to etcd, which without the webhook lacks defaulting.  The controller (via genreconciler + PreProcessReconcile) runs `SetDefaults` prior to each reconciliation.  Instrumenting the test code, the kingresses we create often lack `Percent: 100` when a single service is specified, which creates enough inconsistency for a hash mismatch.

Related: https://github.com/knative/networking/pull/138