### PR TITLE
Add a dummy file so we can import configs

### DIFF
--- a/config/dummy.go
+++ b/config/dummy.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config exists to make the config directory importable.
+package config


### PR DESCRIPTION
This is same with caching's https://github.com/knative/caching/commit/64d6830ca6ddf965bf2ac7354526f502451bf138 but for networking.

/cc @mattmoor @tcnghia @ZhiminXiang 