### PR TITLE
Remove tagHeaderBasedRouting example from config-network.yaml

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "2653766a"
+    knative.dev/example-checksum: "5e3df87d"
 data:
   _example: |
     ################################
@@ -104,8 +104,3 @@ data:
     # 3. Redirected: The Knative ingress will send a 302 redirect for all
     # http connections, asking the clients to use HTTPS.
     httpProtocol: "Enabled"
-
-    # Controls whether tag header based routing feature are enabled or not.
-    # 1. Enabled: enabling tag header based routing
-    # 2. Disabled: disabling tag header based routing.
-    tagHeaderBasedRouting: "Disabled"

--- a/hack/update-checksums.sh
+++ b/hack/update-checksums.sh
@@ -26,4 +26,4 @@ fi
 
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
-go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml
+go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/config/config-*.yaml


### PR DESCRIPTION
This patch removes `tagHeaderBasedRouting` example from config-network.yaml.
It was removed by https://github.com/knative/serving/commit/b564cda38a6468703e85c3f544eacb12baecd1fc.

Also this patch tweaks a filepath against configmap in update-checksums.sh.

/cc @tcnghia @vagababov 