### PR TITLE
Add conformance test for omitted timeout

### DIFF
--- a/test/conformance/ingress/timeout.go
+++ b/test/conformance/ingress/timeout.go
@@ -54,35 +54,16 @@ func TestTimeout(t *testing.T) {
 		}},
 	})
 
-	const timeout = 25 * time.Second
-
-	test := struct {
-		name         string
-		code         int
-		initialDelay time.Duration
-		delay        time.Duration
-	}{
-		name:  "large delay before headers is ok",
-		code:  http.StatusOK,
-		delay: timeout,
-	}
-
-	t.Run(test.name, func(t *testing.T) {
-		checkTimeout(ctx, t, client, name, test.code, test.delay)
-	})
-}
-
-func checkTimeout(ctx context.Context, t *testing.T, client *http.Client, name string, code int, initial time.Duration) {
-	t.Helper()
+	const timeout = 10 * time.Second
 
 	resp, err := client.Get(fmt.Sprintf("http://%s.example.com?initialTimeout=%d",
-		name, initial.Milliseconds()))
+		name, timeout.Milliseconds()))
 	if err != nil {
 		t.Fatal("Error making GET request:", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != code {
-		t.Errorf("Unexpected status code: %d, wanted %d", resp.StatusCode, code)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status code: %d, wanted %d", resp.StatusCode, http.StatusOK)
 		DumpResponse(ctx, t, resp)
 	}
 }

--- a/test/conformance/ingress/timeout.go
+++ b/test/conformance/ingress/timeout.go
@@ -23,25 +23,17 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/test"
 )
 
-// TestTimeout verifies that an Ingress configured with a timeout respects that.
+// TestTimeout verifies that an Ingress implements "no timeout".
 func TestTimeout(t *testing.T) {
 	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateTimeoutService(ctx, t, clients)
-
-	// The timeout, and an epsilon value to use as jitter for testing requests
-	// either hit or miss the timeout (without getting so close that we flake).
-	const (
-		timeout = 5 * time.Second
-		epsilon = 200 * time.Millisecond
-	)
 
 	// Create a simple Ingress over the Service.
 	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
@@ -50,7 +42,6 @@ func TestTimeout(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
-					Timeout: &metav1.Duration{Duration: timeout},
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceName:      name,
@@ -63,40 +54,29 @@ func TestTimeout(t *testing.T) {
 		}},
 	})
 
-	tests := []struct {
+	const timeout = 25 * time.Second
+
+	test := struct {
 		name         string
 		code         int
 		initialDelay time.Duration
 		delay        time.Duration
-	}{{
-		name: "no delays is OK",
-		code: http.StatusOK,
-	}, {
-		name:  "large delay after headers is ok",
+	}{
+		name:  "large delay before headers is ok",
 		code:  http.StatusOK,
-		delay: timeout + timeout,
-	}, {
-		name:         "initial delay less than timeout is ok",
-		code:         http.StatusOK,
-		initialDelay: timeout - epsilon,
-	}, {
-		name:         "initial delay over timeout is NOT ok",
-		code:         http.StatusGatewayTimeout,
-		initialDelay: timeout + epsilon,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			checkTimeout(ctx, t, client, name, test.code, test.initialDelay, test.delay)
-		})
+		delay: timeout,
 	}
+
+	t.Run(test.name, func(t *testing.T) {
+		checkTimeout(ctx, t, client, name, test.code, test.delay)
+	})
 }
 
-func checkTimeout(ctx context.Context, t *testing.T, client *http.Client, name string, code int, initial time.Duration, timeout time.Duration) {
+func checkTimeout(ctx context.Context, t *testing.T, client *http.Client, name string, code int, initial time.Duration) {
 	t.Helper()
 
-	resp, err := client.Get(fmt.Sprintf("http://%s.example.com?initialTimeout=%d&timeout=%d",
-		name, initial.Milliseconds(), timeout.Milliseconds()))
+	resp, err := client.Get(fmt.Sprintf("http://%s.example.com?initialTimeout=%d",
+		name, initial.Milliseconds()))
 	if err != nil {
 		t.Fatal("Error making GET request:", err)
 	}


### PR DESCRIPTION
Currently timeout sets to super long time until Ingress providers
implements the "no timeout".
However there are no conformance test for it so we cannot see if they
implemented it or not.

This patch adds the conformance test for it.

Fixes https://github.com/knative/networking/issues/91

/cc @mattmoor @tcnghia @ZhiminXiang 