### PR TITLE
Remove short-names for gateways with all-numeric Top Level Domains

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -100,9 +101,21 @@ func ExpandedHosts(hosts sets.String) sets.String {
 	for _, h := range hosts.List() {
 		for _, suffix := range allowedSuffixes {
 			if strings.HasSuffix(h, suffix) {
-				expanded.Insert(strings.TrimSuffix(h, suffix))
+				trimmedHost := strings.TrimSuffix(h, suffix)
+				if isValidTopLevelDomain(trimmedHost) {
+					expanded.Insert(trimmedHost)
+				}
 			}
 		}
 	}
 	return expanded
+}
+
+// Validate that the Top Level Domain of a given hostname is not fully numeric.
+// Example: '1234' is an invalid TLD
+func isValidTopLevelDomain(domain string) bool {
+	parts := strings.Split(domain, ".")
+	topLevelDomain := parts[len(parts)-1]
+	_, err := strconv.Atoi(topLevelDomain)
+	return (err != nil)
 }

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -40,6 +40,15 @@ func TestGetExpandedHosts(t *testing.T) {
 			"service.namespace.svc.cluster.local",
 		),
 	}, {
+		name: "cluster local service in all-numeric namespace",
+		hosts: sets.NewString(
+			"service.1234.svc.cluster.local",
+		),
+		want: sets.NewString(
+			"service.1234.svc",
+			"service.1234.svc.cluster.local",
+		),
+	}, {
 		name: "example.com service",
 		hosts: sets.NewString(
 			"foo.bar.example.com",


### PR DESCRIPTION
Fixes [#7742 in Knative Serving](https://github.com/knative/serving/issues/7742)

While exposing short-names for cluster local gateways, validate that the trimmed domain name does not have an all-numeric Top Level Domain.