### PR TITLE
Support skip-tests option to skip some specific tests in alpha or beta features

### DIFF
--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -65,10 +65,10 @@ func RunConformance(t *testing.T) {
 		t.Run(name, test)
 	}
 
-	skipArray := strings.Split(test.ServingFlags.SkipTests, ",")
-	skipTests := make(map[string]struct{}, len(skipArray))
-	for _, name := range skipArray {
-		skipTests[name] = struct{}{}
+	skipTests := strings.Split(test.ServingFlags.SkipTests, ",")
+	for _, name := range skipTests {
+		delete(alphaTests, name)
+		delete(betaTests, name)
 	}
 
 	// TODO(dprotaso) we'll need something more robust
@@ -80,20 +80,12 @@ func RunConformance(t *testing.T) {
 	// ie. requirement - must, should, may
 	if test.ServingFlags.EnableBetaFeatures {
 		for name, test := range betaTests {
-			if _, ok := skipTests[name]; ok {
-				t.Skip(name)
-				continue
-			}
 			t.Run(name, test)
 		}
 	}
 
 	if test.ServingFlags.EnableAlphaFeatures {
 		for name, test := range alphaTests {
-			if _, ok := skipTests[name]; ok {
-				t.Skip(name)
-				continue
-			}
 			t.Run(name, test)
 		}
 	}

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -17,43 +17,59 @@ limitations under the License.
 package ingress
 
 import (
+	"strings"
 	"testing"
 
 	"knative.dev/networking/test"
 )
 
+var stableTests = map[string]func(t *testing.T){
+	"basics":                       TestBasics,
+	"basics/http2":                 TestBasicsHTTP2,
+	"grpc":                         TestGRPC,
+	"grpc/split":                   TestGRPCSplit,
+	"headers/pre-split":            TestPreSplitSetHeaders,
+	"headers/post-split":           TestPostSplitSetHeaders,
+	"hosts/multiple":               TestMultipleHosts,
+	"dispatch/path":                TestPath,
+	"dispatch/percentage":          TestPercentage,
+	"dispatch/path_and_percentage": TestPathAndPercentageSplit,
+	"timeout":                      TestTimeout,
+	"tls":                          TestIngressTLS,
+	"update":                       TestUpdate,
+	"visibility":                   TestVisibility,
+	"visibility/split":             TestVisibilitySplit,
+	"visibility/path":              TestVisibilityPath,
+	"ingressclass":                 TestIngressClass,
+	"websocket":                    TestWebsocket,
+	"websocket/split":              TestWebsocketSplit,
+}
+
+var betaTests = map[string]func(t *testing.T){
+	// Add your conformance test for beta features
+	"headers/probe": TestProbeHeaders,
+}
+
+var alphaTests = map[string]func(t *testing.T){
+	// Add your conformance test for alpha features
+	"headers/tags": TestTagHeaders,
+	"host-rewrite": TestRewriteHost,
+}
+
 // RunConformance will run ingress conformance tests
 //
 // Depending on the options it may test alpha and beta features
 func RunConformance(t *testing.T) {
-	t.Run("basics", TestBasics)
-	t.Run("basics/http2", TestBasicsHTTP2)
 
-	t.Run("grpc", TestGRPC)
-	t.Run("grpc/split", TestGRPCSplit)
+	for name, test := range stableTests {
+		t.Run(name, test)
+	}
 
-	t.Run("headers/pre-split", TestPreSplitSetHeaders)
-	t.Run("headers/post-split", TestPostSplitSetHeaders)
-
-	t.Run("hosts/multiple", TestMultipleHosts)
-
-	t.Run("dispatch/path", TestPath)
-	t.Run("dispatch/percentage", TestPercentage)
-	t.Run("dispatch/path_and_percentage", TestPathAndPercentageSplit)
-
-	t.Run("timeout", TestTimeout)
-
-	t.Run("tls", TestIngressTLS)
-	t.Run("update", TestUpdate)
-
-	t.Run("visibility", TestVisibility)
-	t.Run("visibility/split", TestVisibilitySplit)
-	t.Run("visibility/path", TestVisibilityPath)
-
-	t.Run("ingressclass", TestIngressClass)
-
-	t.Run("websocket", TestWebsocket)
-	t.Run("websocket/split", TestWebsocketSplit)
+	skipArray := strings.Split(test.ServingFlags.SkipTests, ",")
+	skipTests := make(map[string]struct{}, len(skipArray))
+	for _, name := range skipArray {
+		skipTests[name] = struct{}{}
+	}
 
 	// TODO(dprotaso) we'll need something more robust
 	// in the long term that lets downstream
@@ -62,15 +78,24 @@ func RunConformance(t *testing.T) {
 	// dimensions
 	// ie. state - alpha, beta, ga
 	// ie. requirement - must, should, may
-
 	if test.ServingFlags.EnableBetaFeatures {
-		// Add your conformance test for beta features
-		t.Run("headers/probe", TestProbeHeaders)
+		for name, test := range betaTests {
+			if _, ok := skipTests[name]; ok {
+				t.Skip(name)
+				continue
+			}
+			t.Run(name, test)
+		}
 	}
 
 	if test.ServingFlags.EnableAlphaFeatures {
-		// Add your conformance test for alpha features
-		t.Run("headers/tags", TestTagHeaders)
-		t.Run("host-rewrite", TestRewriteHost)
+		for name, test := range alphaTests {
+			if _, ok := skipTests[name]; ok {
+				t.Skip(name)
+				continue
+			}
+			t.Run(name, test)
+		}
 	}
+
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -39,6 +39,7 @@ type ServingEnvironmentFlags struct {
 	Replicas            int    // The number of controlplane replicas being run.
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
 	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
+	SkipTests           string // Indicates the test names we want to skip in alpha or beta features.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -78,12 +79,17 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.BoolVar(&f.EnableAlphaFeatures,
 		"enable-alpha",
 		false,
-		"Set this flag to run tests against alpha features")
+		"Set this flag to run tests against alpha features.")
 
 	flag.BoolVar(&f.EnableBetaFeatures,
 		"enable-beta",
 		false,
-		"Set this flag to run tests against beta features")
+		"Set this flag to run tests against beta features.")
+
+	flag.StringVar(&f.SkipTests,
+		"skip-tests",
+		"",
+		"Set this flag to the tests you want to skip in alpha or beta features. Accepts a comma separated list.")
 
 	return &f
 }


### PR DESCRIPTION
Currently Alpha or Beta conformance tests must be implemented when we enabled the flag.
This patch allows users to skip one or some specific tests in alpha or beta features.

Fixes https://github.com/knative/networking/issues/183
