### PR TITLE
Feature-flag gated tests to validate auto http2/gRPC detection with empty port

### DIFF
--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -95,8 +95,7 @@ func TestHTTP2AndEmptyPort(t *testing.T) {
 	}
 
 	if want, got := 2, ri.Request.ProtoMajor; want != got {
-		// DO NOT SUBMIT
-		t.Fatalf("ProtoMajor = %d, wanted %d", got, want)
+		t.Errorf("ProtoMajor = %d, wanted %d", got, want)
 	}
 }
 

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -100,7 +100,6 @@ func TestHTTP2AndEmptyPort(t *testing.T) {
 }
 
 // TestGRPCWithEmptyPort verifies that a nameless port can establish a basic GRPC connection.
-// DO NOT SUBMIT: This breaks.
 func TestGRPCWithEmptyPort(t *testing.T) {
 	t.Parallel()
 	defer logstream.Start(t)()

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+	ping "knative.dev/networking/test/test_images/grpc-ping/proto"
+	"knative.dev/pkg/test/logstream"
+)
+
+// TestHTTP1AndEmptyPort verifies that an empty port name uses HTTP1. This should be the current behavior.
+func TestHTTP1AndEmptyPort(t *testing.T) {
+	clients := test.Setup(t)
+	name, port, cancel := CreateRuntimeService(t, clients, "")
+	defer cancel()
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+	if ri == nil {
+		return
+	}
+
+	if want, got := 1, ri.Request.ProtoMajor; want != got {
+		t.Errorf("ProtoMajor = %d, wanted %d", got, want)
+	}
+}
+
+// TestHTTP2AndEmptyPort verifies that an empty port name uses HTTP2.
+// This is not the current behavior.
+func TestHTTP2AndEmptyPort(t *testing.T) {
+	clients := test.Setup(t)
+	name, port, cancel := CreateRuntimeService(t, clients, "")
+	defer cancel()
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+	if ri == nil {
+		return
+	}
+
+	if want, got := 2, ri.Request.ProtoMajor; want != got {
+		t.Errorf("ProtoMajor = %d, wanted %d", got, want)
+	}
+}
+
+// TestGRPCWithEmptyPort verifies that a nameless port can establish a basic GRPC connection.
+// DO NOT SUBMIT: This breaks.
+func TestGRPCWithEmptyPort(t *testing.T) {
+	t.Parallel()
+	defer logstream.Start(t)()
+	clients := test.Setup(t)
+
+	const suffix = "- pong"
+	name, port, cancel := CreateGRPCServiceWithPortName(t, clients, suffix, "")
+	defer cancel()
+
+	domain := name + ".example.com"
+
+	// Create a simple Ingress over the Service.
+	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	conn, err := grpc.Dial(
+		domain+":80",
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialCtx(ctx, "unused", addr)
+		}),
+	)
+	if err != nil {
+		t.Fatal("Dial() =", err)
+	}
+	defer conn.Close()
+	pc := ping.NewPingServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := pc.PingStream(ctx)
+	if err != nil {
+		t.Fatal("PingStream() =", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		checkGRPCRoundTrip(t, stream, suffix)
+	}
+}

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -32,6 +32,7 @@ import (
 
 // TestHTTP1AndEmptyPort verifies that an empty port name uses HTTP1. This should be the current behavior.
 func TestHTTP1AndEmptyPort(t *testing.T) {
+	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 	name, port, _ := CreateRuntimeService(ctx, t, clients, "")
 
@@ -67,6 +68,7 @@ func TestHTTP1AndEmptyPort(t *testing.T) {
 // TestHTTP2AndEmptyPort verifies that an empty port name uses HTTP2.
 // This is not the current behavior.
 func TestHTTP2AndEmptyPort(t *testing.T) {
+	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 	name, port, _ := CreateRuntimeService(ctx, t, clients, "")
 

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -32,11 +32,11 @@ import (
 
 // TestHTTP1AndEmptyPort verifies that an empty port name uses HTTP1. This should be the current behavior.
 func TestHTTP1AndEmptyPort(t *testing.T) {
-	clients := test.Setup(t)
-	name, port, _ := CreateRuntimeService(t, clients, "")
+	ctx, clients := context.Background(), test.Setup(t)
+	name, port, _ := CreateRuntimeService(ctx, t, clients, "")
 
 	// Create a simple Ingress over the Service.
-	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -54,7 +54,7 @@ func TestHTTP1AndEmptyPort(t *testing.T) {
 		}},
 	})
 
-	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+	ri := RuntimeRequest(ctx, t, client, "http://"+name+".example.com")
 	if ri == nil {
 		return
 	}
@@ -67,11 +67,11 @@ func TestHTTP1AndEmptyPort(t *testing.T) {
 // TestHTTP2AndEmptyPort verifies that an empty port name uses HTTP2.
 // This is not the current behavior.
 func TestHTTP2AndEmptyPort(t *testing.T) {
-	clients := test.Setup(t)
-	name, port, _ := CreateRuntimeService(t, clients, "")
+	ctx, clients := context.Background(), test.Setup(t)
+	name, port, _ := CreateRuntimeService(ctx, t, clients, "")
 
 	// Create a simple Ingress over the Service.
-	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -89,13 +89,14 @@ func TestHTTP2AndEmptyPort(t *testing.T) {
 		}},
 	})
 
-	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+	ri := RuntimeRequest(ctx, t, client, "http://"+name+".example.com")
 	if ri == nil {
 		return
 	}
 
 	if want, got := 2, ri.Request.ProtoMajor; want != got {
-		t.Errorf("ProtoMajor = %d, wanted %d", got, want)
+		// DO NOT SUBMIT
+		t.Fatalf("ProtoMajor = %d, wanted %d", got, want)
 	}
 }
 
@@ -104,15 +105,15 @@ func TestHTTP2AndEmptyPort(t *testing.T) {
 func TestGRPCWithEmptyPort(t *testing.T) {
 	t.Parallel()
 	defer logstream.Start(t)()
-	clients := test.Setup(t)
+	ctx, clients := context.Background(), test.Setup(t)
 
 	const suffix = "- pong"
-	name, port, _ := CreateGRPCServiceWithPortName(t, clients, suffix, "")
+	name, port, _ := CreateGRPCServiceWithPortName(ctx, t, clients, suffix, "")
 
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -113,7 +113,7 @@ func TestGRPCWithEmptyPort(t *testing.T) {
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, _ := CreateIngressReadyDialContext(ctx, t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := createIngressReadyDialContext(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,

--- a/test/conformance/ingress/emptyport.go
+++ b/test/conformance/ingress/emptyport.go
@@ -33,11 +33,10 @@ import (
 // TestHTTP1AndEmptyPort verifies that an empty port name uses HTTP1. This should be the current behavior.
 func TestHTTP1AndEmptyPort(t *testing.T) {
 	clients := test.Setup(t)
-	name, port, cancel := CreateRuntimeService(t, clients, "")
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, "")
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -54,7 +53,6 @@ func TestHTTP1AndEmptyPort(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
 	if ri == nil {
@@ -70,11 +68,10 @@ func TestHTTP1AndEmptyPort(t *testing.T) {
 // This is not the current behavior.
 func TestHTTP2AndEmptyPort(t *testing.T) {
 	clients := test.Setup(t)
-	name, port, cancel := CreateRuntimeService(t, clients, "")
-	defer cancel()
+	name, port, _ := CreateRuntimeService(t, clients, "")
 
 	// Create a simple Ingress over the Service.
-	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+	_, client, _ := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{name + ".example.com"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -91,7 +88,6 @@ func TestHTTP2AndEmptyPort(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
 	if ri == nil {
@@ -111,13 +107,12 @@ func TestGRPCWithEmptyPort(t *testing.T) {
 	clients := test.Setup(t)
 
 	const suffix = "- pong"
-	name, port, cancel := CreateGRPCServiceWithPortName(t, clients, suffix, "")
-	defer cancel()
+	name, port, _ := CreateGRPCServiceWithPortName(t, clients, suffix, "")
 
 	domain := name + ".example.com"
 
 	// Create a simple Ingress over the Service.
-	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+	_, dialCtx, _ := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{domain},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -134,7 +129,6 @@ func TestGRPCWithEmptyPort(t *testing.T) {
 			},
 		}},
 	})
-	defer cancel()
 
 	conn, err := grpc.Dial(
 		domain+":80",

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -67,13 +67,6 @@ func RunConformance(t *testing.T) {
 
 	skipTests := skipTests()
 
-	t.Run("emptyport/http1", TestHTTP1AndEmptyPort)
-
-	if test.ServingFlags.EnableAutoHttp2 {
-		t.Run("emptyport/http2", TestHTTP2AndEmptyPort)
-		t.Run("emptyport/grpc", TestGRPCWithEmptyPort)
-	}
-
 	// TODO(dprotaso) we'll need something more robust
 	// in the long term that lets downstream
 	// implementations to better select which tests
@@ -99,6 +92,14 @@ func RunConformance(t *testing.T) {
 			}
 			t.Run(name, test)
 		}
+	}
+
+	// TODO(rafaeltc): Once the feature is partially implemented,
+	// move to alphaTests and remove flag.
+	if test.ServingFlags.EnableAutoHttp2 {
+		t.Run("emptyport/http1", TestHTTP1AndEmptyPort)
+		t.Run("emptyport/http2", TestHTTP2AndEmptyPort)
+		t.Run("emptyport/grpc", TestGRPCWithEmptyPort)
 	}
 }
 

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -94,7 +94,7 @@ func RunConformance(t *testing.T) {
 		}
 	}
 
-	// TODO(rafaeltc): Once the feature is partially implemented,
+	// TODO(knative/serving#4283): Once the feature is partially implemented,
 	// move to alphaTests and remove flag.
 	if test.ServingFlags.EnableAutoHttp2 {
 		t.Run("emptyport/http1", TestHTTP1AndEmptyPort)

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -67,6 +67,11 @@ func RunConformance(t *testing.T) {
 
 	skipTests := skipTests()
 
+	// TODO (rafaeltc): Move this to Alpha features before merging.
+	t.Run("h2c/http1", TestHTTP1AndEmptyPort)
+	t.Run("h2c/http2", TestHTTP2AndEmptyPort)
+	t.Run("h2c/grpc", TestGRPCWithEmptyPort)
+
 	// TODO(dprotaso) we'll need something more robust
 	// in the long term that lets downstream
 	// implementations to better select which tests

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -67,10 +67,12 @@ func RunConformance(t *testing.T) {
 
 	skipTests := skipTests()
 
-	// TODO (rafaeltc): Move this to Alpha features before merging.
-	t.Run("h2c/http1", TestHTTP1AndEmptyPort)
-	t.Run("h2c/http2", TestHTTP2AndEmptyPort)
-	t.Run("h2c/grpc", TestGRPCWithEmptyPort)
+	t.Run("emptyport/http1", TestHTTP1AndEmptyPort)
+
+	if test.ServingFlags.EnableAutoHttp2 {
+		t.Run("emptyport/http2", TestHTTP2AndEmptyPort)
+		t.Run("emptyport/grpc", TestGRPCWithEmptyPort)
+	}
 
 	// TODO(dprotaso) we'll need something more robust
 	// in the long term that lets downstream

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -448,9 +448,9 @@ func CreateWebsocketService(ctx context.Context, t *testing.T, clients *test.Cli
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
 }
 
-// CreateGRPCService creates a Kubernetes service that will upgrade the connection
-// to use GRPC and echo back the received messages with the provided suffix.
-func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {
+// CreateGRPCServiceWithPortName creates a Kubernetes service that will upgrade the connection
+// to use GRPC and echo back the received messages with the provided suffix, using a specific port name.
+func CreateGRPCServiceWithPortName(ctx context.Context, t *testing.T, clients *test.Clients, suffix, portName string) (string, int, context.CancelFunc) {
 	t.Helper()
 	name := test.ObjectNameForTest(t)
 
@@ -476,7 +476,7 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 				Image:           pkgTest.ImagePath("grpc-ping"),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Ports: []corev1.ContainerPort{{
-					Name:          networking.ServicePortNameH2C,
+					Name:          portName,
 					ContainerPort: int32(containerPort),
 				}},
 				// This is needed by the runtime image we are using.
@@ -509,7 +509,7 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 		Spec: corev1.ServiceSpec{
 			Type: "ClusterIP",
 			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
+				Name:       portName,
 				Port:       int32(port),
 				TargetPort: intstr.FromInt(containerPort),
 			}},
@@ -520,6 +520,13 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 	}
 
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
+}
+
+// CreateGRPCService creates a Kubernetes service that will upgrade the connection
+// to use GRPC and echo back the received messages with the provided suffix.
+func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {
+	t.Helper()
+	return CreateGRPCServiceWithPortName(ctx, t, clients, suffix, networking.ServicePortNameH2C)
 }
 
 // createService is a helper for creating the service resource.

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -40,6 +40,7 @@ type ServingEnvironmentFlags struct {
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
 	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
 	SkipTests           string // Indicates the test names we want to skip in alpha or beta features.
+	EnableAutoHttp2     bool   // Indicates whether we run tests for http2/gRPC autodetect
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -90,6 +91,11 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 		"skip-tests",
 		"",
 		"Set this flag to the tests you want to skip in alpha or beta features. Accepts a comma separated list.")
+
+	flag.BoolVar(&f.EnableAutoHttp2,
+		"enable-autohttp2",
+		false,
+		"Set this flag to run tests against http2/gRPC autodetect features")
 
 	return &f
 }


### PR DESCRIPTION
Creates new "emptyport" tests to validate protocol used when no port is specified. Currently only 1 of the tests runs all the time, the others are gated behind a new feature flag.

We originally intended to add a more complex support matrix in this change. However, while we can hack the `http.Transport.TLSNextProto` to force a http 1.1 connection, the way the dialer is implemented (by using a TCP connection to the ingress endpoint) makes it meaningless in this test. Conversely, using `http2.Transport` to force a http2-only connection requires us to create an equivalent version of https://github.com/knative/networking/blob/master/test/conformance/ingress/util.go#L902 using a slightly different signature.

We still want to do this, but will probably occur in parallel with the rest of development.

Work is being tracked by https://github.com/knative/serving/issues/4283