### PR TITLE
Remove deprecated generation field

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -88,17 +88,6 @@ type IngressList struct {
 // - Timeout & Retry can be configured.
 // - Headers can be appended.
 type IngressSpec struct {
-	// DeprecatedGeneration was used prior in Kubernetes versions <1.11
-	// when metadata.generation was not being incremented by the api server
-	//
-	// This property will be dropped in future Knative releases and should
-	// not be used - use metadata.generation
-	//
-	// Tracking issue: https://github.com/knative/serving/issues/643
-	//
-	// +optional
-	DeprecatedGeneration int64 `json:"generation,omitempty"`
-
 	// TLS configuration. Currently Ingress only supports a single TLS
 	// port: 443. If multiple members of this list specify different hosts, they
 	// will be multiplexed on the same port according to the hostname specified


### PR DESCRIPTION
This patch removes DeprecatedGeneration from ingress spec.
It was deprecated since https://github.com/knative/serving/pull/2923.

/cc @dprotaso @tcnghia @ZhiminXiang 

Fixes https://github.com/knative/networking/issues/195