### PR TITLE
Add downstream test with serving and net-*

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -183,3 +183,85 @@ jobs:
       with:
         upstream-module: knative.dev/${{ github.event.repository.name }}
         downstream-module: knative.dev/net-kourier
+
+  downstream-net-certmanager:
+    name: Net Certmanager
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/net-certmanager
+        path: ./src/knative.dev/net-certmanager
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/net-certmanager
+
+  downstream-net-http01:
+    name: Net HTTP01
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/net-http01
+        path: ./src/knative.dev/net-http01
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/net-http01

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -1,0 +1,185 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Downstream
+
+on:
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  downstream-serving:
+    name: Serving
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative/serving
+        path: ./src/knative.dev/serving
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/serving
+
+  downstream-net-istio:
+    name: Net Istio
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/net-istio
+        path: ./src/knative.dev/net-istio
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/net-istio
+
+  downstream-net-contour:
+    name: Net Contour
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/net-contour
+        path: ./src/knative.dev/net-contour
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/net-contour
+
+  downstream-net-kourier:
+    name: Net Kourier
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/net-kourier
+        path: ./src/knative.dev/net-kourier
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/net-kourier


### PR DESCRIPTION
This patch adds downstream tests with serving, net-istio, net-contour, net-kourier, net-certmanager and net-http01.

Fixes https://github.com/knative/networking/issues/208

/cc @mattmoor @tcnghia @ZhiminXiang 

