### PR TITLE
Switch to uber.Atomic for probes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/rs/dnscache v0.0.0-20190621150935-06bb5526f76b
+	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/test/prober.go
+++ b/test/prober.go
@@ -24,9 +24,10 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"sync/atomic"
 
+	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
+
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
@@ -51,8 +52,8 @@ type prober struct {
 	url           *url.URL
 	minimumProbes int64
 
-	requests int64
-	failures int64
+	requests atomic.Int64
+	failures atomic.Int64
 
 	// This channel is simply closed when minimumProbes has been satisfied.
 	minDoneCh chan struct{}
@@ -67,7 +68,7 @@ var _ Prober = (*prober)(nil)
 
 // SLI implements Prober
 func (p *prober) SLI() (int64, int64) {
-	return atomic.LoadInt64(&p.requests), atomic.LoadInt64(&p.failures)
+	return p.requests.Load(), p.failures.Load()
 }
 
 // Stop implements Prober
@@ -156,16 +157,16 @@ func (m *manager) Spawn(url *url.URL) Prober {
 				return nil
 			default:
 				res, err := client.Do(req)
-				if atomic.AddInt64(&p.requests, 1) == p.minimumProbes {
+				if p.requests.Inc() == p.minimumProbes {
 					close(p.minDoneCh)
 				}
 				if err != nil {
 					p.logf("%q error: %v", p.url, err)
-					atomic.AddInt64(&p.failures, 1)
+					p.failures.Inc()
 				} else if res.StatusCode != http.StatusOK {
 					p.logf("%q status = %d, want: %d", p.url, res.StatusCode, http.StatusOK)
-					p.logf("response: %s", res)
-					atomic.AddInt64(&p.failures, 1)
+					p.logf("Response: %s", res)
+					p.failures.Inc()
 				}
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,6 +205,7 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.uber.org/atomic v1.6.0
+## explicit
 go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr


### PR DESCRIPTION
This is much more declarative and more readable. And concise. Did I mention readable? Just look at `atomic.Bool`! 🥇 

/assign @JRBANCEL @tcnghia 