### PR TITLE
Rename ServingFlags to NetworkingFlags

### DIFF
--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -48,7 +48,7 @@ func CreateCertificate(ctx context.Context, t *testing.T, clients *test.Clients,
 			Name:      name,
 			Namespace: test.ServingNamespace,
 			Annotations: map[string]string{
-				networking.CertificateClassAnnotationKey: test.ServingFlags.CertificateClass,
+				networking.CertificateClassAnnotationKey: test.NetworkingFlags.CertificateClass,
 			},
 		},
 		Spec: v1alpha1.CertificateSpec{

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -74,7 +74,7 @@ func RunConformance(t *testing.T) {
 	// dimensions
 	// ie. state - alpha, beta, ga
 	// ie. requirement - must, should, may
-	if test.ServingFlags.EnableBetaFeatures {
+	if test.NetworkingFlags.EnableBetaFeatures {
 		for name, test := range betaTests {
 			if _, ok := skipTests[name]; ok {
 				t.Run(name, skipFunc)
@@ -84,7 +84,7 @@ func RunConformance(t *testing.T) {
 		}
 	}
 
-	if test.ServingFlags.EnableAlphaFeatures {
+	if test.NetworkingFlags.EnableAlphaFeatures {
 		for name, test := range alphaTests {
 			if _, ok := skipTests[name]; ok {
 				t.Run(name, skipFunc)
@@ -100,7 +100,7 @@ var skipFunc = func(t *testing.T) {
 }
 
 func skipTests() map[string]struct{} {
-	skipArray := strings.Split(test.ServingFlags.SkipTests, ",")
+	skipArray := strings.Split(test.NetworkingFlags.SkipTests, ",")
 	skipMap := make(map[string]struct{}, len(skipArray))
 	for _, name := range skipArray {
 		skipMap[name] = struct{}{}

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -655,7 +655,7 @@ func createIngress(ctx context.Context, t *testing.T, clients *test.Clients, spe
 			Name:      name,
 			Namespace: test.ServingNamespace,
 			Annotations: map[string]string{
-				networking.IngressClassAnnotationKey: test.ServingFlags.IngressClass,
+				networking.IngressClassAnnotationKey: test.NetworkingFlags.IngressClass,
 			},
 		},
 		Spec: spec,

--- a/test/conformance/ingress/visibility.go
+++ b/test/conformance/ingress/visibility.go
@@ -43,7 +43,7 @@ func TestVisibility(t *testing.T) {
 	shortName := privateServiceName + "." + test.ServingNamespace
 
 	var privateHostNames = map[string]string{
-		"fqdn":     shortName + ".svc." + test.ServingFlags.ClusterSuffix,
+		"fqdn":     shortName + ".svc." + test.NetworkingFlags.ClusterSuffix,
 		"short":    shortName + ".svc",
 		"shortest": shortName,
 	}
@@ -150,7 +150,7 @@ func TestVisibilitySplit(t *testing.T) {
 	name := test.ObjectNameForTest(t)
 
 	// Create a simple Ingress over the 10 Services.
-	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, test.ServingFlags.ClusterSuffix)
+	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, test.NetworkingFlags.ClusterSuffix)
 	localIngress, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{privateHostName},
@@ -254,7 +254,7 @@ func TestVisibilityPath(t *testing.T) {
 	const headerName = "Which-Backend"
 
 	name := test.ObjectNameForTest(t)
-	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, test.ServingFlags.ClusterSuffix)
+	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, test.NetworkingFlags.ClusterSuffix)
 	localIngress, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
 			Hosts:      []string{privateHostName},

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -28,6 +28,10 @@ import (
 // NetworkingFlags holds the flags or defaults for knative/networking settings in the user's environment.
 var NetworkingFlags = initializeNetworkingFlags()
 
+// ServingFlags is an alias of NetworkingFlags.
+// TODO: Delete this variable once all downstream migrate it to NetworkingFlags.
+var ServingFlags = NetworkingFlags
+
 // NetworkingEnvironmentFlags holds the e2e flags needed only by the networking repo.
 type NetworkingEnvironmentFlags struct {
 	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,16 +25,15 @@ import (
 	network "knative.dev/networking/pkg"
 )
 
-// ServingFlags holds the flags or defaults for knative/serving settings in the user's environment.
-var ServingFlags = initializeServingFlags()
+// NetworkingFlags holds the flags or defaults for knative/networking settings in the user's environment.
+var NetworkingFlags = initializeNetworkingFlags()
 
-// ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
-type ServingEnvironmentFlags struct {
+// NetworkingEnvironmentFlags holds the e2e flags needed only by the networking repo.
+type NetworkingEnvironmentFlags struct {
 	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`
 	HTTPS               bool   // Indicates where the test service will be created with https
 	IngressClass        string // Indicates the class of Ingress provider to test.
 	CertificateClass    string // Indicates the class of Certificate provider to test.
-	SystemNamespace     string // Indicates the system namespace, in which Knative Serving is installed.
 	Buckets             int    // The number of reconciler buckets configured.
 	Replicas            int    // The number of controlplane replicas being run.
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
@@ -43,8 +42,8 @@ type ServingEnvironmentFlags struct {
 	ClusterSuffix       string // Specifies the cluster DNS suffix to be used in tests.
 }
 
-func initializeServingFlags() *ServingEnvironmentFlags {
-	var f ServingEnvironmentFlags
+func initializeNetworkingFlags() *NetworkingEnvironmentFlags {
+	var f NetworkingEnvironmentFlags
 
 	// Only define and set flags here. Flag values cannot be read at package init time.
 	flag.BoolVar(&f.ResolvableDomain,

--- a/test/prober.go
+++ b/test/prober.go
@@ -139,7 +139,7 @@ func (m *manager) Spawn(url *url.URL) Prober {
 	m.probes[url] = p
 
 	errGrp.Go(func() error {
-		client, err := pkgTest.NewSpoofingClient(ctx, m.clients.KubeClient, m.logf, url.Hostname(), ServingFlags.ResolvableDomain, m.transportOptions...)
+		client, err := pkgTest.NewSpoofingClient(ctx, m.clients.KubeClient, m.logf, url.Hostname(), NetworkingFlags.ResolvableDomain, m.transportOptions...)
 		if err != nil {
 			return fmt.Errorf("failed to generate client: %w", err)
 		}


### PR DESCRIPTION
This patch changes:
- to rename ServingFlags to NetworkingFlags.
- to delete unused SystemNamespace from NetworkingEnvironmentFlags struct.

/cc @tcnghia @mattmoor @ZhiminXiang 

Fixes https://github.com/knative/networking/issues/211