### PR TITLE
Docs specify that it should be `//nolint`

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -358,7 +358,7 @@ func (m *Prober) processWorkItem() bool {
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
-		// nolint:gosec
+		//nolint:gosec
 		// We only want to know that the Gateway is configured, not that the configuration is valid.
 		// Therefore, we can safely ignore any TLS certificate validation.
 		InsecureSkipVerify: true,


### PR DESCRIPTION
Without spaces: https://golangci-lint.run/usage/false-positives/

/assign @tcnghia @ZhiminXiang 