### PR TITLE
Deprecate Timeout field in Ingress

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -232,11 +232,12 @@ type HTTPIngressPath struct {
 	// +optional
 	AppendHeaders map[string]string `json:"appendHeaders,omitempty"`
 
-	// Timeout for HTTP requests.
+	// DeprecatedTimeout is DEPRECATED.
+	// Timeout is not used anymore. See https://github.com/knative/networking/issues/91
 	//
 	// NOTE: This differs from K8s Ingress which doesn't allow setting timeouts.
 	// +optional
-	Timeout *metav1.Duration `json:"timeout,omitempty"`
+	DeprecatedTimeout *metav1.Duration `json:"timeout,omitempty"`
 
 	// DeprecatedRetries is DEPRECATED.
 	// Retry in Kingress is not used anymore. See https://github.com/knative/serving/issues/6549

--- a/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
@@ -286,8 +286,8 @@ func (in *HTTPIngressPath) DeepCopyInto(out *HTTPIngressPath) {
 			(*out)[key] = val
 		}
 	}
-	if in.Timeout != nil {
-		in, out := &in.Timeout, &out.Timeout
+	if in.DeprecatedTimeout != nil {
+		in, out := &in.DeprecatedTimeout, &out.DeprecatedTimeout
 		*out = new(v1.Duration)
 		**out = **in
 	}


### PR DESCRIPTION
This patch deprecates Timeout in Ingress as it is not used anymore.

The conformance test for omitted timeout was already implemented and
KIngress(net-istio, net-contour, net-kourier) proved to pass the test.

Please also refer to https://github.com/knative/networking/issues/91

/cc @tcnghia @mattmoor @ZhiminXiang 