### PR TITLE
Validate annotation prefixes

### DIFF
--- a/pkg/apis/networking/metadata_validation.go
+++ b/pkg/apis/networking/metadata_validation.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"knative.dev/pkg/apis"
+)
+
+var (
+	allowedAnnotations = sets.NewString(
+		DisableAutoTLSAnnotationKey,
+		CertificateClassAnnotationKey,
+	)
+)
+
+// ValidateAnnotations validates that `annotations` in `metadata` stanza of the
+// resources is correct.
+func ValidateAnnotations(annotations map[string]string) (errs *apis.FieldError) {
+	for key := range annotations {
+		if !allowedAnnotations.Has(key) && strings.HasPrefix(key, "networking.knative.dev") {
+			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))
+		}
+	}
+	return errs
+}

--- a/pkg/apis/networking/metadata_validation_test.go
+++ b/pkg/apis/networking/metadata_validation_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"testing"
+
+	"knative.dev/pkg/apis"
+)
+
+func TestValidateObjectMetadata(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		expectErr   *apis.FieldError
+	}{{
+		name: "invalid knative prefix annotation",
+		annotations: map[string]string{
+			"networking.knative.dev/testAnnotation": "value",
+		},
+		expectErr: apis.ErrInvalidKeyName("networking.knative.dev/testAnnotation", apis.CurrentField),
+	}, {
+		name: "valid non-knative prefix annotation key",
+		annotations: map[string]string{
+			"testAnnotation": "testValue",
+		},
+	}, {
+		name: "valid disable auto TLS annotation key",
+		annotations: map[string]string{
+			DisableAutoTLSAnnotationKey: "true",
+		},
+	}, {
+		name: "valid certificate class annotation key",
+		annotations: map[string]string{
+			CertificateClassAnnotationKey: "certificate-class",
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateAnnotations(c.annotations)
+			if got, want := err.Error(), c.expectErr.Error(); got != want {
+				t.Errorf("Got: %q, want: %q", got, want)
+			}
+		})
+	}
+}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -25,8 +25,9 @@ import (
 )
 
 // Validate inspects and validates ClusterServerlessService object.
-func (ss *ServerlessService) Validate(ctx context.Context) *apis.FieldError {
-	return ss.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
+func (ss *ServerlessService) Validate(ctx context.Context) (errs *apis.FieldError) {
+	return errs.Also(networking.ValidateAnnotations(ss.ObjectMeta.GetAnnotations()).ViaField("annotations")).
+		Also(ss.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
 // Validate inspects and validates ServerlessServiceSpec object.


### PR DESCRIPTION
Validate that annotations with `networking.knative.dev` prefix can only be `networking.knative.dev/disableAutoTLS` and `networking.knative.dev/certificate.class`

Fixes #123 