### PR TITLE
Remove usages of deprecated interfaces

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"testing"
 	// For our e2e testing, we want this linked first so that our
 	// systen namespace environment variable is defaulted prior to
 	// logstream initialization.
@@ -62,7 +63,7 @@ const (
 )
 
 // Setup creates client to run Knative Service requests
-func Setup(t pkgTest.TLegacy) *Clients {
+func Setup(t testing.TB) *Clients {
 	t.Helper()
 
 	cancel := logstream.Start(t)

--- a/test/crd.go
+++ b/test/crd.go
@@ -20,9 +20,7 @@ package test
 
 import (
 	"net/url"
-	"strings"
 
-	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 )
 
@@ -49,10 +47,3 @@ var MakeK8sNamePrefix = helpers.MakeK8sNamePrefix
 
 // ObjectNameForTest generates a random object name based on the test name.
 var ObjectNameForTest = helpers.ObjectNameForTest
-
-// SubServiceNameForTest generates a random service name based on the test name and
-// the given subservice name.
-func SubServiceNameForTest(t pkgTest.T, subsvc string) string {
-	fullPrefix := strings.TrimPrefix(t.Name(), "Test") + "-" + subsvc
-	return AppendRandomString(MakeK8sNamePrefix(fullPrefix))
-}

--- a/test/e2e_constants.go
+++ b/test/e2e_constants.go
@@ -47,7 +47,4 @@ const (
 
 	// ContainerMemoryLimit is used in any test which needs a default memory resource limit
 	ContainerMemoryLimit = "350Mi"
-
-	// testAnnotation is an annotation attached to resources originating from tests.
-	testAnnotation = "knative-e2e-test"
 )

--- a/test/prober.go
+++ b/test/prober.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"testing"
 
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
@@ -232,7 +233,7 @@ func RunRouteProber(logf logging.FormatLogger, clients *Clients, url *url.URL, o
 // AssertProberDefault is a helper for stopping the Prober and checking its SLI
 // against the default SLO, which requires perfect responses.
 // This takes `testing.T` so that it may be used in `defer`.
-func AssertProberDefault(t pkgTest.T, p Prober) {
+func AssertProberDefault(t testing.TB, p Prober) {
 	t.Helper()
 	if err := p.Stop(); err != nil {
 		t.Error("Stop()", "error", err.Error())

--- a/test/util.go
+++ b/test/util.go
@@ -25,10 +25,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/kmeta"
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/signals"
-	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 )
@@ -93,11 +91,4 @@ func PemDataFromSecret(ctx context.Context, logf logging.FormatLogger, clients *
 		return []byte{}
 	}
 	return secret.Data[corev1.TLSCertKey]
-}
-
-// AddTestAnnotation adds the knative-e2e-test label to the resource.
-func AddTestAnnotation(t pkgTest.T, m metav1.ObjectMeta) {
-	kmeta.UnionMaps(m.Annotations, map[string]string{
-		testAnnotation: t.Name(),
-	})
 }


### PR DESCRIPTION
The `pkgTest.T/TLegacy` interfaces have been deprecated, so remove their usage. Some functions aren't used at all (neither here nor in the net-* downstreams) so drop them completely.