### PR TITLE
Move SeverlessService CRD yaml to networking

### DIFF
--- a/config/serverlessservice.yaml
+++ b/config/serverlessservice.yaml
@@ -1,0 +1,66 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Mode
+      type: string
+      jsonPath: ".spec.mode"
+    - name: Activators
+      type: integer
+      jsonPath: ".spec.numActivators"
+    - name: ServiceName
+      type: string
+      jsonPath: ".status.serviceName"
+    - name: PrivateServiceName
+      type: string
+      jsonPath: ".status.privateServiceName"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - sks
+  scope: Namespaced


### PR DESCRIPTION
Move SeverlessService CRD yaml to networking to be near all its friends in the networking.internal.knative.dev package, and its corresponding type definitions, which are already in this repo. See discussion in https://github.com/knative/networking/pull/254.

Lint is probably gonna complain about the copyright header being in 2019, but since this just a move of the same file I think 2019 is right.

(Once this lands I'll update the version in serving to symlink here like we do with https://github.com/knative/serving/blob/master/config/core/300-resources/certificate.yaml and https://github.com/knative/serving/blob/master/config/core/300-resources/ingress.yaml)

/assign @markusthoemmes @mattmoor @tcnghia 