### PR TITLE
This drops the somewhat gratuitous use of t.Parallel in TLS tests.

### DIFF
--- a/test/conformance/ingress/tls.go
+++ b/test/conformance/ingress/tls.go
@@ -60,17 +60,11 @@ func TestIngressTLS(t *testing.T) {
 		}},
 	})
 
-	t.Run("verify HTTP", func(t *testing.T) {
-		t.Parallel()
+	// Check without TLS.
+	RuntimeRequest(ctx, t, client, "http://"+name+".example.com")
 
-		RuntimeRequest(ctx, t, client, "http://"+name+".example.com")
-	})
-
-	t.Run("verify HTTPS", func(t *testing.T) {
-		t.Parallel()
-
-		RuntimeRequest(ctx, t, client, "https://"+name+".example.com")
-	})
+	// Check with TLS.
+	RuntimeRequest(ctx, t, client, "https://"+name+".example.com")
 }
 
 // TODO(mattmoor): Consider adding variants where we have multiple hosts with distinct certificates.


### PR DESCRIPTION
Downstream I'm seeing odd failures in net-contour where it takes ~32s for the kingress to become ready, but the `verify HTTPS` variant doesn't run until the certificate has expired 5 minutes later...

```
util.go:956: Error making GET request: Get "https://ingress-conformance-2-tls-dnewllzp.example.com": x509: certificate has expired or is not yet valid: current time 2020-11-10T19:41:26Z is after 2020-11-10T19:30:22Z
```

In the above test, we updated the status as ready at `19:25:46.726947295`, but didn't attempt the curl until `19:41:26` when the certificate expired at `19:30:22` (exactly 5 minutes after the test logs start).

I suspect that the problem here is actually that the execution of things with `t.Parallel` is highly unpredictable, so this removes the fairly gratuitous use of `t.Parallel` around what should be a simple `Get` request.

/assign @vagababov @tcnghia 