### PR TITLE
Avoid recreating the logger in the ingress prober

### DIFF
--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -691,6 +691,7 @@ func TestProbeVerifier(t *testing.T) {
 		url:      nil,
 		podIP:    "",
 		podPort:  "",
+		logger:   zaptest.NewLogger(t).Sugar(),
 	})
 	cases := []struct {
 		name string


### PR DESCRIPTION
Since this lib is designed to be called in a reconciler, I think it is fair to assume that the context is already carrying the correct logger. Passing it around in the workItems also avoid recreating it over and over.

/assign @tcnghia @vagababov 