### PR TITLE
Add config to disable auto-creation of domain claims

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "eaf5fb3f"
+    knative.dev/example-checksum: "14cd8fa3"
 data:
   _example: |
     ################################
@@ -108,3 +108,14 @@ data:
     # rolloutDuration contains the minimal duration in seconds over which the
     # Configuration traffic targets are rolled out to the newest revision.
     rolloutDuration: "0"
+
+    # autocreateClusterDomainClaims controls whether ClusterDomainClaims should
+    # be automatically created (and deleted) as needed when DomainMappings are
+    # reconciled.
+    #
+    # If this is "false", the cluster administrator is responsible for creating
+    # ClusterDomainClaims and delegating them to namespaces via their
+    # spec.Namespace field. This is useful for multitenant environments
+    # which need to control which namespace can use a particular domain name in
+    # a domain mapping.
+    autocreateClusterDomainClaims: "true"

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -116,6 +116,10 @@ const (
 	// constructing the Knative Route's tag names.
 	DefaultTagTemplate = "{{.Tag}}-{{.Name}}"
 
+	// AutocreateClusterDomainClaimsKey is the key for the
+	// AutocreateClusterDomainClaims property.
+	AutocreateClusterDomainClaimsKey = "autocreateClusterDomainClaims"
+
 	// AutoTLSKey is the name of the configuration entry
 	// that specifies enabling auto-TLS or not.
 	AutoTLSKey = "autoTLS"
@@ -235,6 +239,13 @@ type Config struct {
 
 	// RolloutDurationSecs specifies the default duration for the rollout.
 	RolloutDurationSecs int
+
+	// AutocreateClusterDomainClaims specifies whether cluster-wide DomainClaims
+	// should be automatically created (and deleted) as needed when a
+	// DomainMapping is reconciled. If this is false, the
+	// cluster administrator is responsible for pre-creating ClusterDomainClaims
+	// and delegating them to namespaces via their spec.Namespace field.
+	AutocreateClusterDomainClaims bool
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -254,12 +265,13 @@ const (
 
 func defaultConfig() *Config {
 	return &Config{
-		DefaultIngressClass:     IstioIngressClassName,
-		DefaultCertificateClass: CertManagerCertificateClassName,
-		DomainTemplate:          DefaultDomainTemplate,
-		TagTemplate:             DefaultTagTemplate,
-		AutoTLS:                 false,
-		HTTPProtocol:            HTTPEnabled,
+		DefaultIngressClass:           IstioIngressClassName,
+		DefaultCertificateClass:       CertManagerCertificateClassName,
+		DomainTemplate:                DefaultDomainTemplate,
+		TagTemplate:                   DefaultTagTemplate,
+		AutoTLS:                       false,
+		HTTPProtocol:                  HTTPEnabled,
+		AutocreateClusterDomainClaims: true,
 	}
 }
 
@@ -280,6 +292,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsString(DomainTemplateKey, &nc.DomainTemplate),
 		cm.AsString(TagTemplateKey, &nc.TagTemplate),
 		cm.AsInt(RolloutDurationKey, &nc.RolloutDurationSecs),
+		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -74,7 +74,7 @@ func TestConfiguration(t *testing.T) {
 			return c
 		}(),
 	}, {
-		name: "network configuration with non-default rolout duration",
+		name: "network configuration with non-default rollout duration",
 		data: map[string]string{
 			RolloutDurationKey: "211",
 		},
@@ -93,6 +93,23 @@ func TestConfiguration(t *testing.T) {
 		name: "network configuration with negative rollout duration",
 		data: map[string]string{
 			RolloutDurationKey: "-444",
+		},
+		wantErr: true,
+	}, {
+		name: "network configuration with non-default autocreateClusterDomainClaim value",
+		data: map[string]string{
+			AutocreateClusterDomainClaimsKey: "false",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.AutocreateClusterDomainClaims = false
+			return c
+		}(),
+	}, {
+		name: "network configuration with invalid autocreateClusterDomainClaim value",
+		data: map[string]string{
+			AutocreateClusterDomainClaimsKey: "salad",
 		},
 		wantErr: true,
 	}, {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 


- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Adds `autocreateClusterDomainClaims` flag to network configmap. 

  Used to disable automatic claiming of domain names in favour of explicit delegation of domain name ownership to namespaces via the spec.Namespace field of `ClusterDomainClaim` (this is important for multi-tenant environments which need to prevent 'squatting' or 'intercepting' domain names used in other namespaces but exposed via the shared ingress).

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adds `autocreateClusterDomainClaims` flag to network config map.
```

/assign @mattmoor @tcnghia 
