### PR TITLE
Move RewriteHost conformance tests to Beta

### DIFF
--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -49,12 +49,12 @@ var stableTests = map[string]func(t *testing.T){
 var betaTests = map[string]func(t *testing.T){
 	// Add your conformance test for beta features
 	"headers/probe": TestProbeHeaders,
+	"host-rewrite":  TestRewriteHost,
 }
 
 var alphaTests = map[string]func(t *testing.T){
 	// Add your conformance test for alpha features
 	"headers/tags": TestTagHeaders,
-	"host-rewrite": TestRewriteHost,
 }
 
 // RunConformance will run ingress conformance tests


### PR DESCRIPTION
# Changes

- :gift: Move RewriteHost conformance tests to Beta.

  The main ingresses have implemented it and it has been stable for a couple
releases now. We need RewriteHost to be beta in order to make the
DomainMapping CRD, which relies on RewriteHost, beta.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Moves the RewriteHost KIngress feature tests to beta suite.
```

/assign @mattmoor @tcnghia 
