### PR TITLE
Move TestProbeHeaders tests to stable, TestTagHeaders tests to beta

### DIFF
--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -30,6 +30,7 @@ var stableTests = map[string]func(t *testing.T){
 	"grpc/split":                   TestGRPCSplit,
 	"headers/pre-split":            TestPreSplitSetHeaders,
 	"headers/post-split":           TestPostSplitSetHeaders,
+	"headers/probe":                TestProbeHeaders,
 	"hosts/multiple":               TestMultipleHosts,
 	"dispatch/path":                TestPath,
 	"dispatch/percentage":          TestPercentage,
@@ -48,13 +49,12 @@ var stableTests = map[string]func(t *testing.T){
 
 var betaTests = map[string]func(t *testing.T){
 	// Add your conformance test for beta features
-	"headers/probe": TestProbeHeaders,
-	"host-rewrite":  TestRewriteHost,
+	"host-rewrite": TestRewriteHost,
+	"headers/tags": TestTagHeaders,
 }
 
 var alphaTests = map[string]func(t *testing.T){
 	// Add your conformance test for alpha features
-	"headers/tags": TestTagHeaders,
 }
 
 // RunConformance will run ingress conformance tests


### PR DESCRIPTION
- :gift: Move TestProbeHeaders tests to stable, TestTagHeaders tests to beta

`TestTagHeaders` was added in alpha for long time ago.
`TestProbeHeaders` was added in beta since 9d1a5da.

Both should be promoted as main ingresses have implemented them.

**Release Note**

```release-note
Move TestProbeHeaders tests to stable, TestTagHeaders tests to beta
```

/cc @tcnghia @mattmoor @ZhiminXiang 
