### PR TITLE
Add header for signifying that requests should not be loadbalanced again

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -176,10 +176,10 @@ const (
 	// consistent.
 	VisibilityLabelKey = "networking.knative.dev/visibility"
 
-	// DirectLoadbalancingHeaderName is the name of a header that signifies to
-	// loadbalancers that the respective request should not be loadbalanced again but
-	// sent to the request's target directly.
-	DirectLoadbalancingHeaderName = "K-Direct-Lb"
+	// PassthroughLoadbalancingHeaderName is the name of the header that directs
+	// load balancers to not load balance the respective request but to
+	// send it to the request's target directly.
+	PassthroughLoadbalancingHeaderName = "K-Passthrough-Lb"
 )
 
 // DomainTemplateValues are the available properties people can choose from

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -175,6 +175,11 @@ const (
 	// already using labels for domain, it probably best to keep this
 	// consistent.
 	VisibilityLabelKey = "networking.knative.dev/visibility"
+
+	// DirectLoadbalancingHeaderName is the name of a header that signifies to
+	// loadbalancers that the respective request should not be loadbalanced again but
+	// sent to the request's target directly.
+	DirectLoadbalancingHeaderName = "K-Direct-Lb"
 )
 
 // DomainTemplateValues are the available properties people can choose from


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/10751.

This header is necessary to instruct Ingress (in this case Istio) to not route the request via their Host tables and loadbalance things but rather respect the included IP address and route the request directly.

/assign @nak3 