### PR TITLE
Update KIngress rule path to be a literal string

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -209,11 +209,9 @@ type HTTPIngressRuleValue struct {
 // HTTPIngressPath associates a path regex with a backend. Incoming URLs matching
 // the path are forwarded to the backend.
 type HTTPIngressPath struct {
-	// Path is an extended POSIX regex as defined by IEEE Std 1003.1,
-	// (i.e this follows the egrep/unix syntax, not the perl syntax)
-	// matched against the path of an incoming request. Currently it can
-	// contain characters disallowed from the conventional "path"
-	// part of a URL as defined by RFC 3986. Paths must begin with
+	// Path represents a literal prefix to which this rule should apply.
+	// Currently it can contain characters disallowed from the conventional
+	// "path" part of a URL as defined by RFC 3986. Paths must begin with
 	// a '/'. If unspecified, the path defaults to a catch all sending
 	// traffic to the backend.
 	// +optional


### PR DESCRIPTION
# Changes

:broom: The documentation comment in `ingress_types.go` called for the path of a rule to be an extended POSIX regular expression, but this behavior has not been implemented correctly by any of the networking layers. The Serving component also treats it as a literal when it sets up the path.

This change clarifies the comment to make it clear that this is, in fact, a literal string prefix, and not a regular expression.

You can see the implementation in the Serving component here:
* https://github.com/knative/serving/blob/f7ecef165c02a745eb9c1cec04714e393b86ed3e/pkg/reconciler/route/resources/ingress.go#L233-L257 (this is the only one I could find)

The implementation in net-istio [tries to use a regular expression](https://github.com/knative-sandbox/net-istio/blob/fb452f3b4a21148fc9e068a84a39b44029fc5ae7/pkg/reconciler/ingress/resources/virtual_service.go#L234-L240), but because Envoy uses [exact matching for regular expressions](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routematch-safe-regex) instead of prefix matching, it actually seemingly deviates from the behavior of other networking layers.

On the other hand, net-contour [just uses a regular ol' prefix match](https://github.com/knative-sandbox/net-contour/blob/3df437f48d71594eaaf32acd61465b6e3f9cc7ab/pkg/reconciler/contour/resources/httpproxy.go#L188-L195).

If this change makes sense to you all, I would be happy to open an additional PR against net-istio to make it use a prefix match as well.

See also our discussion over in the Ambassador repository here: https://github.com/datawire/ambassador/issues/3224

/kind cleanup
/cc @kflynn
