### PR TITLE
Add arturenault as networking reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,6 +17,7 @@ approvers:
 # Networking Reviewers
 reviewers:
 - andrew-su
+- arturenault
 - JRBANCEL
 - markusthoemmes
 - mdemirhan


### PR DESCRIPTION
Nominate [arturenault](https://github.com/arturenault) as networking reviewers as he has been contributing much to the networking area in serving, networking, and net-istio.

