### PR TITLE
Add pod-addressability config to config-network

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "c42b8304"
+    knative.dev/example-checksum: "15954d34"
 data:
   _example: |
     ################################
@@ -125,4 +125,7 @@ data:
     # enabled and thus direct-addressability is usually not possible.
     # Consumers like Knative Serving can use this setting to adjust their behavior
     # accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
     enable-mesh-pod-addressability: "false"

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "14cd8fa3"
+    knative.dev/example-checksum: "c42b8304"
 data:
   _example: |
     ################################
@@ -119,3 +119,10 @@ data:
     # which need to control which namespace can use a particular domain name in
     # a domain mapping.
     autocreateClusterDomainClaims: "true"
+
+    # If true, networking plugins can add additional information to deployed
+    # applications to make their pods directly accessible via their IPs even if mesh is
+    # enabled and thus direct-addressability is usually not possible.
+    # Consumers like Knative Serving can use this setting to adjust their behavior
+    # accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
+    enable-mesh-pod-addressability: "false"

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -180,6 +180,9 @@ const (
 	// load balancers to not load balance the respective request but to
 	// send it to the request's target directly.
 	PassthroughLoadbalancingHeaderName = "K-Passthrough-Lb"
+
+	// EnableMeshPodAddressabilityKey is the config for enabling pod addressability in mesh.
+	EnableMeshPodAddressabilityKey = "enable-mesh-pod-addressability"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -251,6 +254,14 @@ type Config struct {
 	// cluster administrator is responsible for pre-creating ClusterDomainClaims
 	// and delegating them to namespaces via their spec.Namespace field.
 	AutocreateClusterDomainClaims bool
+
+	// EnableMeshPodAddressability specifies whether networking plugins will add
+	// additional information to deployed applications to make their pods directl
+	// accessible via their IPs even if mesh is enabled and thus direct-addressability
+	// is usually not possible.
+	// Consumers like Knative Serving can use this setting to adjust their behavior
+	// accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
+	EnableMeshPodAddressability bool
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -298,6 +309,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsString(TagTemplateKey, &nc.TagTemplate),
 		cm.AsInt(RolloutDurationKey, &nc.RolloutDurationSecs),
 		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
+		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -226,6 +226,16 @@ func TestConfiguration(t *testing.T) {
 			HTTPProtocolKey: "under-the-bridge",
 		},
 		wantErr: true,
+	}, {
+		name: "network configuration with enabled pod-addressability",
+		data: map[string]string{
+			EnableMeshPodAddressabilityKey: "true",
+		},
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.EnableMeshPodAddressability = true
+			return c
+		}(),
 	}}
 
 	for _, tt := range networkConfigTests {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Ref https://github.com/knative/serving/issues/10751

For the pod-addressability work we need a setting available to both net-istio and knative-serving so that each can adjust their behavior accordingly. I first added this setting to net-istio, intending to add a second one to knative-serving, but that seems unnecessary if we can have just one in config-network, readable by both. So here we are.

If this merges, I'll roll back the istio specific config of course.

/assign @nak3 @ZhiminXiang @julz 