### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,29 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-# TOC
-- evankanderson
-- grantr
-- markusthoemmes
-- mattmoor
-- tcnghia
-# Networking Approvers
-- JRBANCEL
-- mdemirhan
-- nak3
-- vagababov
-- ZhiminXiang
+- technical-oversight-committee
+- networking-writers
 
 # Networking Reviewers
 reviewers:
-- andrew-su
-- arturenault
-- JRBANCEL
-- markusthoemmes
-- mdemirhan
-- nak3
-- shashwathi
-- tcnghia
-- vagababov
-- yanweiguo
-- ZhiminXiang
+- networking-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,36 @@
 aliases:
-  productivity-approvers:
-  - chaodaiG
-  - chizhg
+  technical-oversight-committee:
+  - evankanderson
+  - grantr
+  - markusthoemmes
+  - rhuss
+
+  networking-reviewers:
+  - JRBANCEL
+  - ZhiminXiang
+  - andrew-su
+  - arturenault
+  - markusthoemmes
+  - nak3
+  - shashwathi
+  - tcnghia
+  - vagababov
+  - yanweiguo
+
+  networking-writers:
+  - JRBANCEL
+  - ZhiminXiang
+  - nak3
+  - tcnghia
+  - vagababov
+
   productivity-reviewers:
-  - chaodaiG
   - coryrc
-  - chizhg
+  - evankanderson
   - steuhs
   - yt3liu
+
+  productivity-writers:
+  - chizhg
+  - n3wscott
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,24 +3,49 @@
 aliases:
   api-core-wg-leads:
   - dprotaso
+  autoscaling-reviewers:
+  - taragu
   autoscaling-wg-leads:
   - markusthoemmes
   - vagababov
+  autoscaling-writers:
+  - julz
+  - markusthoemmes
+  - vagababov
+  - yanweiguo
   channel-wg-leads:
   - matzew
   - slinkydeveloper
+  client-reviewers:
+  - itsmurugappan
   client-wg-leads:
   - navidshaikh
   - rhuss
   client-writers:
+  - dsimansk
+  - maximilien
   - navidshaikh
   - rhuss
   conformance-wg-leads:
   - tayarani
   conformance-writers:
   - tayarani
+  docs-reviewers:
+  - RichardJJG
+  - jonatasbaldin
+  - mpetason
+  - omerbensaadon
+  - snneji
   docs-wg-leads: []
-  docs-writers: []
+  docs-writers:
+  - abrennan89
+  - carieshmarie
+  - richieescarez
+  eventing-reviewers:
+  - aslom
+  - nlopezgi
+  - tayarani
+  - tommyreddad
   eventing-triage:
   - akashrv
   - antoineco
@@ -35,6 +60,7 @@ aliases:
   - vaikas
   eventing-writers:
   - akashrv
+  - aliok
   - antoineco
   - devguyio
   - grantr
@@ -42,6 +68,7 @@ aliases:
   - lionelvillard
   - matzew
   - n3wscott
+  - pierDipi
   - slinkydeveloper
   - vaikas
   - zhongduo
@@ -94,19 +121,82 @@ aliases:
   - knative-prow-releaser-robot
   - knative-prow-robot
   - knative-test-reporter-robot
+  networking-reviewers:
+  - JRBANCEL
+  - ZhiminXiang
+  - andrew-su
+  - arturenault
+  - markusthoemmes
+  - nak3
+  - shashwathi
+  - tcnghia
+  - vagababov
+  - yanweiguo
   networking-wg-leads:
   - ZhiminXiang
   - nak3
   - tcnghia
+  networking-writers:
+  - JRBANCEL
+  - ZhiminXiang
+  - nak3
+  - tcnghia
+  - vagababov
+  operations-reviewers:
+  - Cynocracy
+  - aliok
+  - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
   operations-wg-leads:
   - houshengbo
   operations-writers:
+  - Cynocracy
+  - aliok
   - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
+  pkg-configmap-reviewers:
+  - dprotaso
+  - mattmoor
+  - mdemirhan
+  - vagababov
+  pkg-configmap-writers:
+  - dprotaso
+  - mattmoor
+  - mdemirhan
+  - vagababov
+  pkg-controller-reviewers:
+  - grantr
+  - mattmoor
+  - tcnghia
+  - vagababov
+  - whaught
+  pkg-controller-writers:
+  - grantr
+  - mattmoor
+  - tcnghia
+  - vagababov
+  productivity-reviewers:
+  - coryrc
+  - efiturri
+  - evankanderson
+  - peterfeifanchen
+  - steuhs
+  - yt3liu
   productivity-wg-leads:
   - chizhg
   - n3wscott
   productivity-writers:
+  - chaodaiG
   - chizhg
+  - coryrc
   - n3wscott
   security-wg-leads:
   - evankanderson
@@ -114,11 +204,19 @@ aliases:
   security-writers:
   - evankanderson
   - julz
+  serving-observability-reviewers:
+  - mdemirhan
+  - skonto
+  - yanweiguo
+  serving-observability-writers:
+  - mdemirhan
+  - yanweiguo
+  serving-reviewers:
+  - julz
+  - whaught
   serving-writers:
-  - ZhiminXiang
   - dprotaso
   - markusthoemmes
-  - nak3
   - tcnghia
   - vagababov
   source-wg-leads:

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
