### PR TITLE
Add main branch in knative-downstream.yaml to trigger test by pull request

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -16,7 +16,7 @@ name: Downstream
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 


### PR DESCRIPTION
`knative-downstream.yaml` missed `main` branch so this patch adds it.
Other workflow files in `.github/workflows/*` have it correctly.

/cc @ZhiminXiang @tcnghia @markusthoemmes 
