### PR TITLE
Add helper to test for potential mesh errors

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -484,3 +484,13 @@ func PortNumberForName(sub corev1.EndpointSubset, portName string) (int32, error
 	}
 	return 0, fmt.Errorf("no port for name %q found", portName)
 }
+
+// IsPotentialMeshErrorResponse returns whether the HTTP response is compatible
+// with having been caused by attempting direct connection when mesh was
+// enabled. For example if we get a HTTP 404 status code it's safe to assume
+// mesh is not enabled even if a probe was otherwise unsuccessful. This is
+// useful to avoid falling back to ClusterIP when we see errors which are
+// unrelated to mesh being enabled.
+func IsPotentialMeshErrorResponse(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusServiceUnavailable
+}

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -19,6 +19,7 @@ package pkg
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -671,6 +672,34 @@ func TestPortNumberForName(t *testing.T) {
 			}
 			if tc.err == nil && portNumber != tc.portNumber {
 				t.Errorf("PortNumber = %d, want: %d", portNumber, tc.portNumber)
+			}
+		})
+	}
+}
+
+func TestIsPotentialMeshErrorResponse(t *testing.T) {
+	for _, test := range []struct {
+		statusCode int
+		expect     bool
+	}{{
+		statusCode: 404,
+		expect:     false,
+	}, {
+		statusCode: 200,
+		expect:     false,
+	}, {
+		statusCode: 200,
+		expect:     false,
+	}, {
+		statusCode: 503,
+		expect:     true,
+	}} {
+		t.Run(fmt.Sprintf("statusCode=%d", test.statusCode), func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: test.statusCode,
+			}
+			if got := IsPotentialMeshErrorResponse(resp); got != test.expect {
+				t.Errorf("IsPotentialMeshErrorResponse({StatusCode: %d}) = %v, expected %v", resp.StatusCode, got, test.expect)
 			}
 		})
 	}

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -688,7 +688,7 @@ func TestIsPotentialMeshErrorResponse(t *testing.T) {
 		statusCode: 200,
 		expect:     false,
 	}, {
-		statusCode: 200,
+		statusCode: 502,
 		expect:     false,
 	}, {
 		statusCode: 503,


### PR DESCRIPTION

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add helper to test for potential mesh errors. 
   - This is useful to distinguish between errors which should and shouldnt cause fallback to clusterIP (see https://github.com/knative/serving/pull/11208, https://github.com/knative/serving/pull/11174)


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adds `IsPotentialMeshErrorResponse` helper to aid distinguishing between responses that should or should not cause fall-back to cluster IP.
```

/assign @markusthoemmes @vagababov 