### PR TITLE
Allow the prober to cancel probing by key

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -313,6 +313,11 @@ func (m *Prober) CancelIngressProbing(obj interface{}) {
 	}
 
 	key := types.NamespacedName{Namespace: acc.GetNamespace(), Name: acc.GetName()}
+	m.CancelIngressProbingByKey(key)
+}
+
+// CancelIngressProbingByKey cancels probing of the Ingress identified by the provided key.
+func (m *Prober) CancelIngressProbingByKey(key types.NamespacedName) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if state, ok := m.ingressStates[key]; ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This adds the possibility to not only stop probing an Ingress by passing the ingress object, but also by passing just the namespace + name pair identifying the Ingress. See https://github.com/knative-sandbox/net-kourier/pull/497 for an example as to why this is necessary: When the object is already deleted, we only know the key.

/assign @nak3 @julz 