### PR TITLE
Add missing JSON tag to protocol type

### DIFF
--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -103,7 +103,7 @@ type ServerlessServiceSpec struct {
 
 	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
 	// serving imports networking, so just use string.
-	ProtocolType networking.ProtocolType
+	ProtocolType networking.ProtocolType `json:"protocolType"`
 
 	// NumActivators contains number of Activators that this revision should be
 	// assigned.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title. Existing object in etcd will have `ProtocolType` (uppercase) as a key, but this should be backwards compatible as `Unmarshal` allows for case-insensitive matching

> To unmarshal JSON into a struct, Unmarshal matches incoming object keys to the keys used by Marshal (either the struct field name or its tag), preferring an exact match but also accepting a case-insensitive match.

(https://golang.org/pkg/encoding/json/#Unmarshal)

/assign @vagababov 