### PR TITLE
Remove deprecated cert and key field

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -41,11 +41,7 @@ func (is *IngressSpec) SetDefaults(ctx context.Context) {
 }
 
 // SetDefaults populates default values in IngressTLS
-func (t *IngressTLS) SetDefaults(ctx context.Context) {
-	// Deprecated, do not use.
-	t.DeprecatedServerCertificate = ""
-	t.DeprecatedPrivateKey = ""
-}
+func (t *IngressTLS) SetDefaults(ctx context.Context) {}
 
 // SetDefaults populates default values in IngressRule
 func (r *IngressRule) SetDefaults(ctx context.Context) {

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -151,16 +151,6 @@ type IngressTLS struct {
 
 	// SecretNamespace is the namespace of the secret used to terminate SSL traffic.
 	SecretNamespace string `json:"secretNamespace,omitempty"`
-
-	// ServerCertificate identifies the certificate filename in the secret.
-	// Defaults to `tls.crt`.
-	// +optional
-	DeprecatedServerCertificate string `json:"serverCertificate,omitempty"`
-
-	// PrivateKey identifies the private key filename in the secret.
-	// Defaults to `tls.key`.
-	// +optional
-	DeprecatedPrivateKey string `json:"privateKey,omitempty"`
 }
 
 // IngressRule represents the rules mapping the paths under a specified host to


### PR DESCRIPTION
This patch removes `DeprecatedServerCertificate` and
`DeprecatedPrivateKey`.

They are deprecatd more than a year ago https://github.com/knative/serving/pull/6340
and it should be alright to remove.

/cc @tcnghia @ZhiminXiang @markusthoemmes 
