### PR TITLE
Replace redirect code 302 with 301 in config-network's comment

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "15954d34"
+    knative.dev/example-checksum: "386cf23d"
 data:
   _example: |
     ################################
@@ -101,7 +101,7 @@ data:
     # It requires autoTLS to be enabled.
     # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
     # 2. Disabled: The Knative ingress will reject HTTP traffic.
-    # 3. Redirected: The Knative ingress will send a 302 redirect for all
+    # 3. Redirected: The Knative ingress will send a 301 redirect for all
     # http connections, asking the clients to use HTTPS.
     httpProtocol: "Enabled"
 

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -742,6 +742,12 @@ func TestProbeVerifier(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "HTTP 301",
+		resp: &http.Response{
+			StatusCode: http.StatusMovedPermanently,
+		},
+		want: true,
+	}, {
 		name: "HTTP 302",
 		resp: &http.Response{
 			StatusCode: http.StatusFound,


### PR DESCRIPTION
The `http` to `https` redirect is usually 301 rather than 302.

This patch changes the config-network comment and add test case for
status probe with `301`.

/cc @julz @markusthoemmes 