### PR TITLE
Add configuration to override internal and external scheme

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "386cf23d"
+    knative.dev/example-checksum: "8f56afee"
 data:
   _example: |
     ################################
@@ -129,3 +129,12 @@ data:
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
     enable-mesh-pod-addressability: "false"
+
+    # If set, overrides the scheme used for external URLs.
+    # This can be used for making Knative report all URLs as "HTTPS" for example, if you're
+    # fronting Knative with an external loadbalancer that deals with TLS termination and
+    # Knative doesn't know about that otherwise.
+    overrideExternalScheme: ""
+
+    # If set, overrides the scheme used for internal URLs.
+    overrideInternalScheme: ""

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -180,6 +180,12 @@ const (
 
 	// EnableMeshPodAddressabilityKey is the config for enabling pod addressability in mesh.
 	EnableMeshPodAddressabilityKey = "enable-mesh-pod-addressability"
+
+	// OverrideExternalSchemeKey is the config for overriding the scheme of external URLs.
+	OverrideExternalSchemeKey = "overrideExternalScheme"
+
+	// OverrideInternalSchemeKey is the config for overriding the scheme of internal URLs.
+	OverrideInternalSchemeKey = "overrideInternalScheme"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -259,6 +265,14 @@ type Config struct {
 	// Consumers like Knative Serving can use this setting to adjust their behavior
 	// accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
 	EnableMeshPodAddressability bool
+
+	// OverrideExternalScheme overrides the scheme used in external URLs (http by default
+	// or https if AutoTLS is enabled) to the set value.
+	OverrideExternalScheme string
+
+	// OverrideInternalScheme overrides the scheme used in interal URLs (http by default)
+	// to the set value.
+	OverrideInternalScheme string
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -306,6 +320,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsInt(RolloutDurationKey, &nc.RolloutDurationSecs),
 		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
 		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
+		cm.AsString(OverrideExternalSchemeKey, &nc.OverrideExternalScheme),
+		cm.AsString(OverrideInternalSchemeKey, &nc.OverrideInternalScheme),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -237,6 +237,18 @@ func TestConfiguration(t *testing.T) {
 			c.EnableMeshPodAddressability = true
 			return c
 		}(),
+	}, {
+		name: "network configuration with overridden external and internal scheme",
+		data: map[string]string{
+			OverrideExternalSchemeKey: "https",
+			OverrideInternalSchemeKey: "ws",
+		},
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.OverrideExternalScheme = "https"
+			c.OverrideInternalScheme = "ws"
+			return c
+		}(),
 	}}
 
 	for _, tt := range networkConfigTests {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Ref #425 

This adds the necessary configuration to make it possible to override external and internal schemes in Knative Routes.