### PR TITLE
Remove overrideInternalScheme and change semantics to defaulting

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "8f56afee"
+    knative.dev/example-checksum: "3e010c60"
 data:
   _example: |
     ################################
@@ -130,11 +130,9 @@ data:
     #       for now. Use with caution.
     enable-mesh-pod-addressability: "false"
 
-    # If set, overrides the scheme used for external URLs.
+    # Defines the scheme used for external URLs.
     # This can be used for making Knative report all URLs as "HTTPS" for example, if you're
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
-    overrideExternalScheme: ""
-
-    # If set, overrides the scheme used for internal URLs.
-    overrideInternalScheme: ""
+    # AutoTLS scheme semantics are left untouched.
+    defaultExternalScheme: "http"

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "3e010c60"
+    knative.dev/example-checksum: "4bd9f3fd"
 data:
   _example: |
     ################################
@@ -130,9 +130,8 @@ data:
     #       for now. Use with caution.
     enable-mesh-pod-addressability: "false"
 
-    # Defines the scheme used for external URLs.
+    # Defines the scheme used for external URLs if autoTLS is not enabled.
     # This can be used for making Knative report all URLs as "HTTPS" for example, if you're
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
-    # AutoTLS scheme semantics are left untouched.
     defaultExternalScheme: "http"

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -181,11 +181,8 @@ const (
 	// EnableMeshPodAddressabilityKey is the config for enabling pod addressability in mesh.
 	EnableMeshPodAddressabilityKey = "enable-mesh-pod-addressability"
 
-	// OverrideExternalSchemeKey is the config for overriding the scheme of external URLs.
-	OverrideExternalSchemeKey = "overrideExternalScheme"
-
-	// OverrideInternalSchemeKey is the config for overriding the scheme of internal URLs.
-	OverrideInternalSchemeKey = "overrideInternalScheme"
+	// DefaultExternalSchemeKey is the config for defining the scheme of external URLs.
+	DefaultExternalSchemeKey = "defaultExternalScheme"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -266,13 +263,9 @@ type Config struct {
 	// accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
 	EnableMeshPodAddressability bool
 
-	// OverrideExternalScheme overrides the scheme used in external URLs (http by default
-	// or https if AutoTLS is enabled) to the set value.
-	OverrideExternalScheme string
-
-	// OverrideInternalScheme overrides the scheme used in interal URLs (http by default)
-	// to the set value.
-	OverrideInternalScheme string
+	// DefaultExternalScheme defines the scheme used in external URLs. Defaults to "http".
+	// AutoTLS scheme semantics are left untouched.
+	DefaultExternalScheme string
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -299,6 +292,7 @@ func defaultConfig() *Config {
 		AutoTLS:                       false,
 		HTTPProtocol:                  HTTPEnabled,
 		AutocreateClusterDomainClaims: true,
+		DefaultExternalScheme:         "http",
 	}
 }
 
@@ -320,8 +314,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsInt(RolloutDurationKey, &nc.RolloutDurationSecs),
 		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
 		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
-		cm.AsString(OverrideExternalSchemeKey, &nc.OverrideExternalScheme),
-		cm.AsString(OverrideInternalSchemeKey, &nc.OverrideInternalScheme),
+		cm.AsString(DefaultExternalSchemeKey, &nc.DefaultExternalScheme),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -263,8 +263,8 @@ type Config struct {
 	// accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
 	EnableMeshPodAddressability bool
 
-	// DefaultExternalScheme defines the scheme used in external URLs. Defaults to "http".
-	// AutoTLS scheme semantics are left untouched.
+	// DefaultExternalScheme defines the scheme used in external URLs if AutoTLS is
+	// not enabled. Defaults to "http".
 	DefaultExternalScheme string
 }
 

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -240,13 +240,11 @@ func TestConfiguration(t *testing.T) {
 	}, {
 		name: "network configuration with overridden external and internal scheme",
 		data: map[string]string{
-			OverrideExternalSchemeKey: "https",
-			OverrideInternalSchemeKey: "ws",
+			DefaultExternalSchemeKey: "https",
 		},
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.OverrideExternalScheme = "https"
-			c.OverrideInternalScheme = "ws"
+			c.DefaultExternalScheme = "https"
 			return c
 		}(),
 	}}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title. 

1. It was pointed out by @julz that semantics are not actually as described. We're going to leave AutoTLS alone for now. If people are using it, there's a good chance they want the semantics it provides and not muck with it, I think.
2. I wasn't sure about the usefulness of `overrideInternalScheme`, so I dropped it for now until somebody brings a use-case that actually needs it.
