### PR TITLE
Change default for autocreateClusterDomainClaims

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "4bd9f3fd"
+    knative.dev/example-checksum: "d38faef1"
 data:
   _example: |
     ################################
@@ -113,12 +113,15 @@ data:
     # be automatically created (and deleted) as needed when DomainMappings are
     # reconciled.
     #
-    # If this is "false", the cluster administrator is responsible for creating
-    # ClusterDomainClaims and delegating them to namespaces via their
-    # spec.Namespace field. This is useful for multitenant environments
-    # which need to control which namespace can use a particular domain name in
-    # a domain mapping.
-    autocreateClusterDomainClaims: "true"
+    # If this is "false" (the default), the cluster administrator is
+    # responsible for creating ClusterDomainClaims and delegating them to
+    # namespaces via their spec.Namespace field. This setting should be used in
+    # multitenant environments which need to control which namespace can use a
+    # particular domain name in a domain mapping.
+    #
+    # If this is "true", users are able to associate arbitrary names with their
+    # services via the DomainMapping feature.
+    autocreateClusterDomainClaims: "false"
 
     # If true, networking plugins can add additional information to deployed
     # applications to make their pods directly accessible via their IPs even if mesh is

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -291,7 +291,7 @@ func defaultConfig() *Config {
 		TagTemplate:                   DefaultTagTemplate,
 		AutoTLS:                       false,
 		HTTPProtocol:                  HTTPEnabled,
-		AutocreateClusterDomainClaims: true,
+		AutocreateClusterDomainClaims: false,
 		DefaultExternalScheme:         "http",
 	}
 }


### PR DESCRIPTION
In preparation for making the DomainMapping feature beta, picking the
more conservative default for this setting so that administrators must
explicitly delegate the ability for namespaces to create a DomainMapping
with a particular name.

Users using Knative locally or in single tenant installations can
change this value to true for a nicer UX.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind api-change



<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Changes the default for autocreateClusterDomainClaims to false, in preparation for making the DomainMapping feature beta. Users deploying Knative in single tenant clusters may wish to change this parameter back to "true" in config-network to allow arbitrary users to create DomainMappings in their namespaces without creating a matching ClusterDomainClaim.
```

/assign @dprotaso @markusthoemmes 
