### PR TITLE
Remove deprecated label `networking.internal.knative.dev/disableWildcardCert`

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -74,10 +74,6 @@ const (
 	// Cert-Manager-based Certificate will reconcile into a Cert-Manager Certificate).
 	CertificateClassAnnotationKey = "networking.knative.dev/certificate.class"
 
-	// DeprecatedDisableWildcardCertLabelKey is the deprecated label key attached to a namespace to indicate that
-	// a wildcard certificate should be not created for it.
-	DeprecatedDisableWildcardCertLabelKey = GroupName + "/disableWildcardCert"
-
 	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.
 	DisableWildcardCertLabelKey = "networking.knative.dev/disableWildcardCert"


### PR DESCRIPTION
/kind cleanup

As per title, the label was removed in serving repo https://github.com/knative/serving/commit/3d23011278339b467b280b8a3ed361e7ab7b5b8f,
so it should be safe to remove.
