### PR TITLE
Add a new test case to request unexpected hash

### DIFF
--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -64,6 +64,14 @@ func TestProbeHeaders(t *testing.T) {
 		t.Error("Failed to compute hash:", err)
 	}
 
+	// create a hash from a different Ingress.
+	another := ing.DeepCopy()
+	another.Spec.Rules[0].Visibility = v1alpha1.IngressVisibilityClusterLocal
+	wrong, _ := ingress.ComputeHash(another)
+	if err != nil {
+		t.Error("Failed to compute hash:", err)
+	}
+
 	tests := []struct {
 		name string
 		req  string
@@ -73,9 +81,13 @@ func TestProbeHeaders(t *testing.T) {
 		req:  network.HashHeaderValue,
 		want: fmt.Sprintf("%x", bytes),
 	}, {
-		name: "request overrides hash",
-		req:  "2701a1b241db6af811992c57a5e11171847148ac3d2e1a8cc992a62f9e4fa111", // random hash to override.
-		want: "2701a1b241db6af811992c57a5e11171847148ac3d2e1a8cc992a62f9e4fa111",
+		name: "request unexpected hash",
+		req:  fmt.Sprintf("%x", wrong),
+		want: fmt.Sprintf("%x", bytes),
+	}, {
+		name: "request corresponding hash",
+		req:  fmt.Sprintf("%x", bytes),
+		want: fmt.Sprintf("%x", bytes),
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently probe request verfies two cases as per https://github.com/knative/networking/issues/113

req:
```
K-Network-Hash: override
```
exp:
```
K-Network-Hash: {hash reflecting config}
```
req:
```
K-Network-Hash: {(correct) hex}
```
exp:
```
K-Network-Hash: {(correct) hex}
```

This patch adds the case:

req:
```
K-Network-Hash: {(wrong) hex}
```
exp:
```
K-Network-Hash: {(correct) hex}
```

The unexpected hash case happens when Ingress was updated.
In the real case, It is captured by https://github.com/knative/networking/blob/8925a5091ec70221e49095df3e14a5ba2c69fee8/pkg/status/status.go#L464