### PR TITLE
Bump go version in knative-downstream.yaml

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -41,6 +41,10 @@ jobs:
         go-version: ${{ matrix.go-version }}
       id: go
 
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
     - name: Checkout Upstream
       uses: actions/checkout@v2
       with:
@@ -78,6 +82,10 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
       id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
 
     - name: Checkout Upstream
       uses: actions/checkout@v2

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -41,10 +41,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
       id: go
 
-    - name: Install Dependencies
-      run: |
-        go get github.com/google/go-licenses
-
     - name: Checkout Upstream
       uses: actions/checkout@v2
       with:
@@ -82,10 +78,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
       id: go
-
-    - name: Install Dependencies
-      run: |
-        go get github.com/google/go-licenses
 
     - name: Checkout Upstream
       uses: actions/checkout@v2

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -24,7 +24,7 @@ jobs:
     name: knative-${{ matrix.repository }}
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
         repository: [serving]
 
@@ -62,7 +62,7 @@ jobs:
     name: knative-sandbox-${{ matrix.repository }}
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
         repository: [net-istio, net-contour, net-kourier, net-certmanager, net-http01]
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,9 +39,11 @@ aliases:
   - snneji
   docs-wg-leads: []
   docs-writers:
+  - RichardJJG
   - abrennan89
   - carieshmarie
   - richieescarez
+  - snneji
   eventing-reviewers:
   - aslom
   - tayarani
@@ -202,6 +204,7 @@ aliases:
   - yanweiguo
   serving-reviewers:
   - julz
+  - psschwei
   - whaught
   serving-writers:
   - dprotaso


### PR DESCRIPTION
Bump go version in knative-downstream.yaml to 1.16.x.

/cc @ZhiminXiang @markusthoemmes 