### PR TITLE
Bump Golang version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/networking
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-openapi/spec v0.19.6 // indirect


### PR DESCRIPTION
As per title, make consistent with other repos. 
Tests (github action) also uses Go 1.16.