### PR TITLE
Use actual cluster domain for TestRewriteHost

### DIFF
--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/test"
-	"knative.dev/pkg/network"
 )
 
 // TestRewriteHost verifies that a RewriteHost rule can be used to implement vanity URLs.
@@ -35,7 +34,7 @@ func TestRewriteHost(t *testing.T) {
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
 	privateServiceName := test.ObjectNameForTest(t)
-	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + network.GetClusterDomainName()
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + test.NetworkingFlags.ClusterSuffix
 
 	// Create a simple Ingress over the Service.
 	ing, _, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{

--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/test"
+	"knative.dev/pkg/network"
 )
 
 // TestRewriteHost verifies that a RewriteHost rule can be used to implement vanity URLs.
@@ -34,7 +35,7 @@ func TestRewriteHost(t *testing.T) {
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 
 	privateServiceName := test.ObjectNameForTest(t)
-	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc.cluster.local"
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + network.GetClusterDomainName()
 
 	// Create a simple Ingress over the Service.
 	ing, _, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{


### PR DESCRIPTION
The cluster domain is not always `cluster.local`. It could be a value defined by users.

So this patch replace the hard-coded `cluster.local` with `ClusterSuffix` via command line option.

P.S. I wondered why current test works and realized that the local domain is not used as https://github.com/knative/networking/blob/main/test/conformance/ingress/util.go#L553 actually.
So we can also use `privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc"`.
