### PR TITLE
Clean up deprecated fields

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -35,9 +35,6 @@ func (is *IngressSpec) SetDefaults(ctx context.Context) {
 	for i := range is.Rules {
 		is.Rules[i].SetDefaults(ctx)
 	}
-
-	// Deprecated, do not use.
-	is.DeprecatedVisibility = ""
 }
 
 // SetDefaults populates default values in IngressTLS
@@ -64,6 +61,4 @@ func (h *HTTPIngressPath) SetDefaults(ctx context.Context) {
 	if len(h.Splits) == 1 && h.Splits[0].Percent == 0 {
 		h.Splits[0].Percent = 100
 	}
-	// Deprecated, do not use.
-	h.DeprecatedRetries = nil
 }

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -46,9 +46,6 @@ func (is *IngressStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 // InitializeConditions initializes conditions of an IngressStatus
 func (is *IngressStatus) InitializeConditions() {
 	ingressCondSet.Manage(is).InitializeConditions()
-
-	// Deprecated, do not set.
-	is.DeprecatedLoadBalancer = nil
 }
 
 // MarkNetworkConfigured set IngressConditionNetworkConfigured in IngressStatus as true

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -103,14 +103,6 @@ type IngressSpec struct {
 	// HTTPOption is the option of HTTP. It has the following two values:
 	// `HTTPOptionEnabled`, `HTTPOptionRedirected`
 	HTTPOption HTTPOption `json:"httpOption,omitempty"`
-
-	// DeprecatedVisibility was used for the fallback when spec.rules.visibility
-	// isn't set.
-	//
-	// Now spec.rules.visibility is not optional and so we make this field deprecated.
-	//
-	// +optional
-	DeprecatedVisibility IngressVisibility `json:"visibility,omitempty"`
 }
 
 type HTTPOption string
@@ -237,18 +229,6 @@ type HTTPIngressPath struct {
 	// NOTE: This differs from K8s Ingress which doesn't allow header appending.
 	// +optional
 	AppendHeaders map[string]string `json:"appendHeaders,omitempty"`
-
-	// DeprecatedTimeout is DEPRECATED.
-	// Timeout is not used anymore. See https://github.com/knative/networking/issues/91
-	//
-	// NOTE: This differs from K8s Ingress which doesn't allow setting timeouts.
-	// +optional
-	DeprecatedTimeout *metav1.Duration `json:"timeout,omitempty"`
-
-	// DeprecatedRetries is DEPRECATED.
-	// Retry in Kingress is not used anymore. See https://github.com/knative/serving/issues/6549
-	// +optional
-	DeprecatedRetries *HTTPRetry `json:"retries,omitempty"`
 }
 
 // IngressBackendSplit describes all endpoints for a given service and port.
@@ -296,11 +276,6 @@ type HTTPRetry struct {
 // IngressStatus describe the current state of the Ingress.
 type IngressStatus struct {
 	duckv1.Status `json:",inline"`
-
-	// DeprecatedLoadBalancer contains the current status of the load-balancer.
-	// DEPRECATED: Use `PublicLoadBalancer` and `PrivateLoadBalancer` instead.
-	// +optional
-	DeprecatedLoadBalancer *LoadBalancerStatus `json:"loadBalancer,omitempty"`
 
 	// PublicLoadBalancer contains the current status of the load-balancer.
 	// +optional

--- a/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/v1alpha1/zz_generated.deepcopy.go
@@ -362,16 +362,6 @@ func (in *HTTPIngressPath) DeepCopyInto(out *HTTPIngressPath) {
 			(*out)[key] = val
 		}
 	}
-	if in.DeprecatedTimeout != nil {
-		in, out := &in.DeprecatedTimeout, &out.DeprecatedTimeout
-		*out = new(v1.Duration)
-		**out = **in
-	}
-	if in.DeprecatedRetries != nil {
-		in, out := &in.DeprecatedRetries, &out.DeprecatedRetries
-		*out = new(HTTPRetry)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 
@@ -623,11 +613,6 @@ func (in *IngressSpec) DeepCopy() *IngressSpec {
 func (in *IngressStatus) DeepCopyInto(out *IngressStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.DeprecatedLoadBalancer != nil {
-		in, out := &in.DeprecatedLoadBalancer, &out.DeprecatedLoadBalancer
-		*out = new(LoadBalancerStatus)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.PublicLoadBalancer != nil {
 		in, out := &in.PublicLoadBalancer, &out.PublicLoadBalancer
 		*out = new(LoadBalancerStatus)


### PR DESCRIPTION
This patch cleans up deprecated fields.

All of them were deprecated since 12 months ago.

`DeprecatedVisibility` .. https://github.com/knative/networking/pull/129
`DeprecatedTimeout` .. https://github.com/knative/networking/pull/228
`DeprecatedLoadBalancer` .. https://github.com/knative/networking/pull/137
`DeprecatedRetries` .. https://github.com/knative/networking/pull/132

/cc @ZhiminXiang @tcnghia 
