### PR TITLE
Allow 502 codes as well as 503 to indicate mesh errors

### DIFF
--- a/pkg/network.go
+++ b/pkg/network.go
@@ -501,5 +501,5 @@ func PortNumberForName(sub corev1.EndpointSubset, portName string) (int32, error
 // useful to avoid falling back to ClusterIP when we see errors which are
 // unrelated to mesh being enabled.
 func IsPotentialMeshErrorResponse(resp *http.Response) bool {
-	return resp.StatusCode == http.StatusServiceUnavailable
+	return resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusBadGateway
 }

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -698,8 +698,11 @@ func TestIsPotentialMeshErrorResponse(t *testing.T) {
 		statusCode: 200,
 		expect:     false,
 	}, {
-		statusCode: 502,
+		statusCode: 501,
 		expect:     false,
+	}, {
+		statusCode: 502,
+		expect:     true,
 	}, {
 		statusCode: 503,
 		expect:     true,


### PR DESCRIPTION
We've had at least 2 reports now that in some cases with mesh enabled we see 502 codes instead of 503s, so seems to make sense to broaden the heuristic to accept those when considering whether we should fall back to mesh mode. In the past we accepted _any_ error to cause mesh fallback, so broadening seems pretty reasonable.

See https://github.com/knative/serving/issues/11877.

/assign @markusthoemmes @nak3 
~~/hold to see https://github.com/knative/serving/pull/11900 pass~~