### PR TITLE
Add mesh-compatibility-mode to network config map

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "d38faef1"
+    knative.dev/example-checksum: "325e5f98"
 data:
   _example: |
     ################################
@@ -132,6 +132,16 @@ data:
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
     enable-mesh-pod-addressability: "false"
+
+    # mesh-compatibility-mode indicates whether consumers of network plugins
+    # should directly contact Pod IPs (most efficient), or should use the
+    # Cluster IP (less efficient, needed when mesh is enabled unless
+    # `enable-mesh-pod-addressability`, above, is set).
+    # Permitted values are:
+    #  - "auto" (default): automatically determine which mesh mode to use by trying Pod IP and falling back to Cluster IP as needed.
+    #  - "enabled": always use Cluster IP and do not attempt to use Pod IPs.
+    #  - "disabled": always use Pod IPs and do not fall back to Cluster IP on failure.
+    mesh-compatibility-mode: "auto"
 
     # Defines the scheme used for external URLs if autoTLS is not enabled.
     # This can be used for making Knative report all URLs as "HTTPS" for example, if you're

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -238,6 +238,26 @@ func TestConfiguration(t *testing.T) {
 			return c
 		}(),
 	}, {
+		name: "network configuration with enabled mesh compatibility mode",
+		data: map[string]string{
+			MeshCompatibilityModeKey: "enabled",
+		},
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.MeshCompatibilityMode = MeshCompatibilityModeEnabled
+			return c
+		}(),
+	}, {
+		name: "network configuration with disabled mesh compatibility mode",
+		data: map[string]string{
+			MeshCompatibilityModeKey: "disabled",
+		},
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.MeshCompatibilityMode = MeshCompatibilityModeDisabled
+			return c
+		}(),
+	}, {
 		name: "network configuration with overridden external and internal scheme",
 		data: map[string]string{
 			DefaultExternalSchemeKey: "https",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add mesh compatibility mode field to config map to tell consumers whether to try direct Pod IP mode or cluster IP mode without heuristic guessing.

Decided to put this here rather than autoscaler config map since the description mentions another field (enable-mesh-addressability) in the same configmap, and I think keeping these together feels "right". Can move it over if anyone feels strongly otherwise.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/knative/serving/issues/11895
Related PRs: https://github.com/knative/serving/pull/11976 https://github.com/knative/serving/pull/11913
<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Adds a mesh-compatibility-mode field to the config map which consumers can use to determine whether to attempt direct Pod IP communication, or should limit communications to the Cluster IP.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @markusthoemmes @dprotaso @ZhiminXiang @nak3 