### PR TITLE
Allow to skip non-alpha/beta tests

### DIFF
--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -63,12 +63,15 @@ var alphaTests = map[string]func(t *testing.T){
 //
 // Depending on the options it may test alpha and beta features
 func RunConformance(t *testing.T) {
+	skipTests := skipTests()
 
 	for name, test := range stableTests {
+		if _, ok := skipTests[name]; ok {
+			t.Run(name, skipFunc)
+			continue
+		}
 		t.Run(name, test)
 	}
-
-	skipTests := skipTests()
 
 	// TODO(dprotaso) we'll need something more robust
 	// in the long term that lets downstream


### PR DESCRIPTION
The `--skip-tests` flag was introduced to skip alpha or beta tests
before and it does not allow to skip stable test.

But now, to support gateway-api, we need to skip some stable tests as some
features are not supported even by the upstream.