### PR TITLE
Introduce kebab-case annotation variants 

### DIFF
--- a/pkg/apis/networking/metadata_validation.go
+++ b/pkg/apis/networking/metadata_validation.go
@@ -26,9 +26,15 @@ import (
 
 var (
 	allowedAnnotations = sets.NewString(
-		DisableAutoTLSAnnotationKey,
+		IngressClassAnnotationKey,
 		CertificateClassAnnotationKey,
+		DisableAutoTLSAnnotationKey,
 		HTTPOptionAnnotationKey,
+
+		IngressClassAnnotationAltKey,
+		CertificateClassAnnotationAltKey,
+		DisableAutoTLSAnnotationAltKey,
+		HTTPProtocolAnnotationKey,
 	)
 )
 

--- a/pkg/apis/networking/metadata_validation_test.go
+++ b/pkg/apis/networking/metadata_validation_test.go
@@ -41,17 +41,26 @@ func TestValidateObjectMetadata(t *testing.T) {
 	}, {
 		name: "valid disable auto TLS annotation key",
 		annotations: map[string]string{
-			DisableAutoTLSAnnotationKey: "true",
+			DisableAutoTLSAnnotationKey:    "true",
+			DisableAutoTLSAnnotationAltKey: "true",
 		},
 	}, {
 		name: "valid certificate class annotation key",
 		annotations: map[string]string{
-			CertificateClassAnnotationKey: "certificate-class",
+			CertificateClassAnnotationKey:    "certificate.class",
+			CertificateClassAnnotationAltKey: "certificate-class",
 		},
 	}, {
 		name: "valid http option annotation key",
 		annotations: map[string]string{
-			HTTPOptionAnnotationKey: "Redirected",
+			HTTPOptionAnnotationKey:   "Redirected",
+			HTTPProtocolAnnotationKey: "Redirected",
+		},
+	}, {
+		name: "valid ingress class annotation key",
+		annotations: map[string]string{
+			IngressClassAnnotationKey:    "ingress.class",
+			IngressClassAnnotationAltKey: "ingress-class",
 		},
 	}}
 

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -20,29 +20,6 @@ const (
 	// GroupName is the name for the networking API group.
 	GroupName = "networking.internal.knative.dev"
 
-	// IngressClassAnnotationKey is the annotation for the
-	// explicit class of Ingress that a particular resource has
-	// opted into. For example,
-	//
-	//    networking.knative.dev/ingress.class: some-network-impl
-	//
-	// This uses a different domain because unlike the resource, it is
-	// user-facing.
-	//
-	// The parent resource may use its own annotations to choose the
-	// annotation value for the Ingress it uses.  Based on such
-	// value a different reconciliation logic may be used (for examples,
-	// Istio-based Ingress will reconcile into a VirtualService).
-	IngressClassAnnotationKey = "networking.knative.dev/ingress.class"
-
-	// DisableAutoTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
-	// to indicate that AutoTLS should not be enabled for it.
-	DisableAutoTLSAnnotationKey = "networking.knative.dev/disableAutoTLS"
-
-	// HTTPOptionAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
-	// to indicate the HTTP option of it.
-	HTTPOptionAnnotationKey = "networking.knative.dev/httpOption"
-
 	// IngressLabelKey is the label key attached to underlying network programming
 	// resources to indicate which Ingress triggered their creation.
 	IngressLabelKey = GroupName + "/ingress"
@@ -58,6 +35,11 @@ const (
 	// RolloutAnnotationKey is the annotation key for storing
 	// the rollout state in the Annotations of the Kingress or Route.Status.
 	RolloutAnnotationKey = GroupName + "/rollout"
+)
+
+const (
+	// PublicGroupName is the name for hte public networking API group
+	PublicGroupName = "networking.knative.dev"
 
 	// CertificateClassAnnotationKey is the annotation for the
 	// explicit class of Certificate that a particular resource has
@@ -72,11 +54,54 @@ const (
 	// annotation value for the Certificate it uses.  Based on such
 	// value a different reconciliation logic may be used (for examples,
 	// Cert-Manager-based Certificate will reconcile into a Cert-Manager Certificate).
-	CertificateClassAnnotationKey = "networking.knative.dev/certificate.class"
+	CertificateClassAnnotationKey = PublicGroupName + "/certificate.class"
+
+	// CertificateClassAnnotationAltKey is an alternative casing to CertificateClassAnnotationKey
+	//
+	// This annotation is meant to be applied to Knative Services or Routes. Serving
+	// will translate this to original casing for better compatability with different
+	// certificate providers
+	CertificateClassAnnotationAltKey = PublicGroupName + "/certificate-class"
+
+	// DisableAutoTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
+	// to indicate that AutoTLS should not be enabled for it.
+	DisableAutoTLSAnnotationKey = PublicGroupName + "/disableAutoTLS"
+
+	// DisableAutoTLSAnnotationAltKey is an alternative casing to DisableAutoTLSAnnotationKey
+	DisableAutoTLSAnnotationAltKey = PublicGroupName + "/disable-auto-tls"
+
+	// HTTPOptionAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
+	// to indicate the HTTP option of it.
+	HTTPOptionAnnotationKey = PublicGroupName + "/httpOption"
+
+	// HTTPProtocolAnnotationKey is an alternative to HTTPOptionAnnotationKey
+	HTTPProtocolAnnotationKey = PublicGroupName + "/http-protocol"
+
+	// IngressClassAnnotationKey is the annotation for the
+	// explicit class of Ingress that a particular resource has
+	// opted into. For example,
+	//
+	//    networking.knative.dev/ingress.class: some-network-impl
+	//
+	// This uses a different domain because unlike the resource, it is
+	// user-facing.
+	//
+	// The parent resource may use its own annotations to choose the
+	// annotation value for the Ingress it uses.  Based on such
+	// value a different reconciliation logic may be used (for examples,
+	// Istio-based Ingress will reconcile into a VirtualService).
+	IngressClassAnnotationKey = PublicGroupName + "/ingress.class"
+
+	// IngressClassAnnotationAltKey is an alternative casing to IngressClassAnnotationKey
+	//
+	// This annotation is meant to be applied to Knative Services or Routes. Serving
+	// will translate this to original casing for better compatability with different
+	// ingress providers
+	IngressClassAnnotationAltKey = PublicGroupName + "/ingress-class"
 
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
-	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
+	WildcardCertDomainLabelKey = PublicGroupName + "/wildcard-domain"
 )
 
 // Pseudo-constants
@@ -86,17 +111,33 @@ var (
 )
 
 func GetIngressClass(annotations map[string]string) (val string) {
+	val, ok := annotations[IngressClassAnnotationAltKey]
+	if ok {
+		return val
+	}
 	return annotations[IngressClassAnnotationKey]
 }
 
 func GetCertificateClass(annotations map[string]string) (val string) {
+	val, ok := annotations[CertificateClassAnnotationAltKey]
+	if ok {
+		return val
+	}
 	return annotations[CertificateClassAnnotationKey]
 }
 
 func GetHTTPProtocol(annotations map[string]string) (val string) {
+	val, ok := annotations[HTTPProtocolAnnotationKey]
+	if ok {
+		return val
+	}
 	return annotations[HTTPOptionAnnotationKey]
 }
 
 func GetDisableAutoTLS(annotations map[string]string) (val string) {
+	val, ok := annotations[DisableAutoTLSAnnotationAltKey]
+	if ok {
+		return val
+	}
 	return annotations[DisableAutoTLSAnnotationKey]
 }

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -59,7 +59,7 @@ const (
 	// CertificateClassAnnotationAltKey is an alternative casing to CertificateClassAnnotationKey
 	//
 	// This annotation is meant to be applied to Knative Services or Routes. Serving
-	// will translate this to original casing for better compatability with different
+	// will translate this to original casing for better compatibility with different
 	// certificate providers
 	CertificateClassAnnotationAltKey = PublicGroupName + "/certificate-class"
 
@@ -95,7 +95,7 @@ const (
 	// IngressClassAnnotationAltKey is an alternative casing to IngressClassAnnotationKey
 	//
 	// This annotation is meant to be applied to Knative Services or Routes. Serving
-	// will translate this to original casing for better compatability with different
+	// will translate this to original casing for better compatibility with different
 	// ingress providers
 	IngressClassAnnotationAltKey = PublicGroupName + "/ingress-class"
 


### PR DESCRIPTION
Introduce alternative annotation with kebab-case to be consistent with other parts of Knative Serving.

Serving will accept these variants on public resources (Service, Route) and use the older variants for now since those are more widely supported. 