### PR TITLE
remove networking.DisableWildcardCertLabelKey

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -74,10 +74,6 @@ const (
 	// Cert-Manager-based Certificate will reconcile into a Cert-Manager Certificate).
 	CertificateClassAnnotationKey = "networking.knative.dev/certificate.class"
 
-	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
-	// a wildcard certificate should be not created for it.
-	DisableWildcardCertLabelKey = "networking.knative.dev/disableWildcardCert"
-
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"


### PR DESCRIPTION
Operators choose the label key to use in their selectors - so the constant is no longer necessary
