### PR TITLE
Use Protocol instead of Option

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -93,7 +93,7 @@ func GetCertificateClass(annotations map[string]string) (val string) {
 	return annotations[CertificateClassAnnotationKey]
 }
 
-func GetHTTPOption(annotations map[string]string) (val string) {
+func GetHTTPProtocol(annotations map[string]string) (val string) {
 	return annotations[HTTPOptionAnnotationKey]
 }
 


### PR DESCRIPTION
Continuing https://github.com/knative/networking/pull/567

I realize we'll want the new annotation to have the same name (http-protocol) as the config map property key


https://github.com/knative/networking/blob/6547bb6d3d1a9905e16efe4849459894a01bbfc8/pkg/network.go#L130-L132