### PR TITLE
revert the case change for the wildcard cert domain label

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -101,7 +101,7 @@ const (
 
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
-	WildcardCertDomainLabelKey = PublicGroupName + "/wildcard-domain"
+	WildcardCertDomainLabelKey = PublicGroupName + "/wildcardDomain"
 )
 
 // Pseudo-constants


### PR DESCRIPTION
I didn't mean to commit this and it's internal so the casing is less important


The reason for changing this back is so that the existing label selection works in serving. Otherwise we need a label selector over two label keys which doesn't seem necessary for an annotation that I consider 'internal'