### PR TITLE
[wip] host rewrite can target multiple K8s service variants

### DIFF
--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -27,7 +27,145 @@ import (
 )
 
 // TestRewriteHost verifies that a RewriteHost rule can be used to implement vanity URLs.
-func TestRewriteHost(t *testing.T) {
+func TestRewriteHost_HeadlessWithEndpointSlice_FQDN(t *testing.T) {
+	t.Parallel()
+	ctx, clients := context.Background(), test.Setup(t)
+
+	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+
+	privateServiceName := test.ObjectNameForTest(t)
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + test.NetworkingFlags.ClusterSuffix
+
+	// Create a simple Ingress over the Service.
+	ing, _, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Hosts:      []string{privateHostName},
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	// Slap an ExternalName service in front of the kingress
+	loadbalancerAddress := ing.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
+	createServiceWithEndpointSliceFQDN(ctx, t, clients, privateHostName, loadbalancerAddress)
+
+	hosts := []string{
+		"vanity.ismy.name",
+		"vanity.isalsomy.number",
+	}
+
+	// Using fixed hostnames can lead to conflicts when -count=N>1
+	// so pseudo-randomize the hostnames to avoid conflicts.
+	for i, host := range hosts {
+		hosts[i] = name + "." + host
+	}
+
+	// Now create a RewriteHost ingress to point a custom Host at the Service
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      hosts,
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					RewriteHost: privateHostName,
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      privateServiceName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(80),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	for _, host := range hosts {
+		RuntimeRequest(ctx, t, client, "http://"+host)
+	}
+}
+func TestRewriteHost_HeadlessWithEndpoint(t *testing.T) {
+	t.Parallel()
+	ctx, clients := context.Background(), test.Setup(t)
+
+	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+
+	privateServiceName := test.ObjectNameForTest(t)
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + test.NetworkingFlags.ClusterSuffix
+
+	// Create a simple Ingress over the Service.
+	ing, _, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Hosts:      []string{privateHostName},
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	// Slap an Manual Service with Endpoint IP in front of the kingress
+	ip := ing.Status.PrivateLoadBalancer.Ingress[0].IP
+	if ip == "" {
+		ip = getInternalIP(ctx, t, ing, clients)
+	}
+	createServiceWithEndpointIP(ctx, t, clients, privateHostName, ip)
+
+	hosts := []string{
+		"vanity.ismy.name",
+		"vanity.isalsomy.number",
+	}
+
+	// Using fixed hostnames can lead to conflicts when -count=N>1
+	// so pseudo-randomize the hostnames to avoid conflicts.
+	for i, host := range hosts {
+		hosts[i] = name + "." + host
+	}
+
+	// Now create a RewriteHost ingress to point a custom Host at the Service
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      hosts,
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					RewriteHost: privateHostName,
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      privateServiceName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(80),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	for _, host := range hosts {
+		RuntimeRequest(ctx, t, client, "http://"+host)
+	}
+}
+
+func TestRewriteHost_ExternalName(t *testing.T) {
 	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -34,7 +34,7 @@ var stableTests = map[string]func(t *testing.T){
 	"hosts/multiple":               TestMultipleHosts,
 	"dispatch/path":                TestPath,
 	"dispatch/percentage":          TestPercentage,
-	"dispatch/path_and_percentage": TestPathAndPercentageSplit,
+	"dispatch/path-and-percentage": TestPathAndPercentageSplit,
 	"dispatch/rule":                TestRule,
 	"retry":                        TestRetry,
 	"timeout":                      TestTimeout,
@@ -50,8 +50,10 @@ var stableTests = map[string]func(t *testing.T){
 
 var betaTests = map[string]func(t *testing.T){
 	// Add your conformance test for beta features
-	"host-rewrite": TestRewriteHost,
-	"headers/tags": TestTagHeaders,
+	"host-rewrite/external-name":       TestRewriteHost_ExternalName,
+	"host-rewrite/headless-service":    TestRewriteHost_HeadlessWithEndpoint,
+	"host-rewrite/endpoint-slice-fqdn": TestRewriteHost_HeadlessWithEndpointSlice_FQDN,
+	"headers/tags":                     TestTagHeaders,
 }
 
 var alphaTests = map[string]func(t *testing.T){


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/11821

Add the different K8s service types as potential targets for the Host Rewrite functionality.

