### PR TITLE
Add `activator-ca` and `activator-name` keys in `config-network`

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "6e2033e0"
+    knative.dev/example-checksum: "70491d06"
 data:
   _example: |
     ################################
@@ -172,3 +172,19 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
+
+    # The CA public certificate used to sign the activator TLS certificate.
+    # It is specified by the secret name, which has the "ca.crt" data field.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    activator-ca: ""
+
+    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
+    # It is available only when "activator-ca" is specified.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    activator-name: ""

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "70491d06"
+    knative.dev/example-checksum: "ddc3250f"
 data:
   _example: |
     ################################
@@ -187,4 +187,4 @@ data:
     #
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
-    activator-name: ""
+    activator-san: ""

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -194,8 +194,8 @@ const (
 	// to sign the activator TLS certificate.
 	ActivatorCAKey = "activator-ca"
 
-	// ActivatorNameKey is the config for the SAN used to validate the activator TLS certificate.
-	ActivatorNameKey = "activator-name"
+	// ActivatorSANKey is the config for the SAN used to validate the activator TLS certificate.
+	ActivatorSANKey = "activator-san"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -299,9 +299,9 @@ type Config struct {
 	// The traffic is not encrypted if ActivatorCA is empty.
 	ActivatorCA string
 
-	// ActivatorName defines the SAN (Subject Alt Name) used to validate the activator TLS certificate.
+	// ActivatorSAN defines the SAN (Subject Alt Name) used to validate the activator TLS certificate.
 	// It is used only when ActivatorCA is specified.
-	ActivatorName string
+	ActivatorSAN string
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -358,7 +358,7 @@ func defaultConfig() *Config {
 		DefaultExternalScheme:         "http",
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
 		ActivatorCA:                   "",
-		ActivatorName:                 "",
+		ActivatorSAN:                  "",
 	}
 }
 
@@ -391,7 +391,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
 		cm.AsString(DefaultExternalSchemeKey, &nc.DefaultExternalScheme),
 		cm.AsString(ActivatorCAKey, &nc.ActivatorCA),
-		cm.AsString(ActivatorNameKey, &nc.ActivatorName),
+		cm.AsString(ActivatorSANKey, &nc.ActivatorSAN),
 		asMode(MeshCompatibilityModeKey, &nc.MeshCompatibilityMode),
 		asLabelSelector(NamespaceWildcardCertSelectorKey, &nc.NamespaceWildcardCertSelector),
 	); err != nil {

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -189,6 +189,13 @@ const (
 
 	// DefaultExternalSchemeKey is the config for defining the scheme of external URLs.
 	DefaultExternalSchemeKey = "default-external-scheme"
+
+	// ActivatorCAKey is the config for the secret name, which stores CA public certificate used
+	// to sign the activator TLS certificate.
+	ActivatorCAKey = "activator-ca"
+
+	// ActivatorNameKey is the config for the SAN used to validate the activator TLS certificate.
+	ActivatorNameKey = "activator-name"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -287,6 +294,14 @@ type Config struct {
 	// DefaultExternalScheme defines the scheme used in external URLs if AutoTLS is
 	// not enabled. Defaults to "http".
 	DefaultExternalScheme string
+
+	// ActivatorCA defines the secret name of the CA public certificate used to sign the activator TLS certificate.
+	// The traffic is not encrypted if ActivatorCA is empty.
+	ActivatorCA string
+
+	// ActivatorName defines the SAN (Subject Alt Name) used to validate the activator TLS certificate.
+	// It is used only when ActivatorCA is specified.
+	ActivatorName string
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -342,6 +357,8 @@ func defaultConfig() *Config {
 		AutocreateClusterDomainClaims: false,
 		DefaultExternalScheme:         "http",
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
+		ActivatorCA:                   "",
+		ActivatorName:                 "",
 	}
 }
 
@@ -373,6 +390,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
 		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
 		cm.AsString(DefaultExternalSchemeKey, &nc.DefaultExternalScheme),
+		cm.AsString(ActivatorCAKey, &nc.ActivatorCA),
+		cm.AsString(ActivatorNameKey, &nc.ActivatorName),
 		asMode(MeshCompatibilityModeKey, &nc.MeshCompatibilityMode),
 		asLabelSelector(NamespaceWildcardCertSelectorKey, &nc.NamespaceWildcardCertSelector),
 	); err != nil {


### PR DESCRIPTION
This pach adds `activator-ca` and `activator-name` keys in `config-network`.

Part of https://github.com/knative-sandbox/net-kourier/issues/750
https://github.com/knative-sandbox/net-kourier/pull/761 demonstrates how it works.

/cc @evankanderson @julz @carlisia 