### PR TITLE
Support TLS server for each test image

### DIFF
--- a/test/conformance/ingress/README.md
+++ b/test/conformance/ingress/README.md
@@ -124,6 +124,31 @@ If `INGRESS_CLASS` is already set, then you can simply `go test ingress_test.go`
 
 NOTE: You will need to run `go mod vendor` for every change you make.
 
-```
+### Running the tests with TLS server
 
-```
+Each test image can run the server with TLS. If you specified the secret name, which stores server certificate, via `UPSTREAM_TLS_CERT`
+env variable, the servers are running with TLS server.
+
+The following steps show how you can use it:
+
+1. Create server certificate with the name `server-certs` in `serving-tests` namespace.
+
+  ```shell
+  $ kubectl create -n serving-tests secret tls server-certs \
+      --key=tls.key --cert=tls.crt
+  ```
+
+1. Set env variable `UPSTREAM_TLS_CERT=server-certs` and run the tests.
+
+  ```shell
+  $ export UPSTREAM_TLS_CERT=server-certs
+  $ go test -race -count=1 -tags=e2e ./test/conformance/ -run "TestIngressConformance/basic"
+  ```
+
+1. The backend test server starts running with TLS.
+
+  ```shell
+  $ kubectl -n serving-tests logs ingress-conformance-basics-tfpnykaw
+  2022/01/27 11:54:14 Server starting on port with TLS 8047
+    ...
+  ```

--- a/test/test_images/grpc-ping/main.go
+++ b/test/test_images/grpc-ping/main.go
@@ -107,5 +107,9 @@ func main() {
 
 	ping.RegisterPingServiceServer(g, &server{})
 
-	log.Fatal(s.ListenAndServe())
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Fatal(s.ListenAndServeTLS(cert, key))
+	} else {
+		log.Fatal(s.ListenAndServe())
+	}
 }

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -88,8 +88,15 @@ func main() {
 	handler = network.NewProbeHandler(handler).ServeHTTP
 
 	address := ":" + port
-	log.Print("Listening on address: ", address)
-	test.ListenAndServeGracefully(address, handler)
+
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Print("Listening on address with TLS: ", address)
+		test.ListenAndServeTLSGracefullyWithHandler(cert, key, ":"+port, handler)
+	} else {
+		log.Print("Listening on address: ", address)
+		test.ListenAndServeGracefully(address, handler)
+	}
+
 }
 
 // newDNSCachingTransport caches DNS lookups locally to avoid issues like

--- a/test/test_images/retry/main.go
+++ b/test/test_images/retry/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -38,5 +39,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	h := network.NewProbeHandler(http.HandlerFunc(handler))
-	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+	port := os.Getenv("PORT")
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Print("Server starting on port with TLS ", port)
+		test.ListenAndServeTLSGracefully(cert, key, ":"+port, h.ServeHTTP)
+	} else {
+		log.Print("Server starting on port ", port)
+		test.ListenAndServeGracefully(":"+port, h.ServeHTTP)
+	}
 }

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -48,6 +48,11 @@ func main() {
 	mux := http.NewServeMux()
 	handlers.InitHandlers(mux)
 
-	log.Print("Server starting on port ", port)
-	test.ListenAndServeGracefullyWithHandler(":"+port, mux)
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Print("Server starting on port with TLS ", port)
+		test.ListenAndServeTLSGracefullyWithHandler(cert, key, ":"+port, mux)
+	} else {
+		log.Print("Server starting on port ", port)
+		test.ListenAndServeGracefullyWithHandler(":"+port, mux)
+	}
 }

--- a/test/test_images/timeout/timeout.go
+++ b/test/test_images/timeout/timeout.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -51,5 +52,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	h := network.NewProbeHandler(http.HandlerFunc(handler))
-	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+	port := os.Getenv("PORT")
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Print("Server starting on port with TLS ", port)
+		test.ListenAndServeTLSGracefully(cert, key, ":"+port, h.ServeHTTP)
+	} else {
+		log.Print("Server starting on port ", port)
+		test.ListenAndServeGracefully(":"+port, h.ServeHTTP)
+	}
 }

--- a/test/test_images/wsserver/echo.go
+++ b/test/test_images/wsserver/echo.go
@@ -86,5 +86,12 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 	h := network.NewProbeHandler(http.HandlerFunc(handler))
-	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+	port := os.Getenv("PORT")
+	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
+		log.Print("Server starting on port with TLS ", port)
+		test.ListenAndServeTLSGracefully(cert, key, ":"+port, h.ServeHTTP)
+	} else {
+		log.Print("Server starting on port ", port)
+		test.ListenAndServeGracefully(":"+port, h.ServeHTTP)
+	}
 }


### PR DESCRIPTION
This pach supports TLS server on each test image.
It needs to verify if Ingress surely connects to the backend with TLS.

The usage is as follows:

1. Create server certificate with the name `server-certs` in `serving-tests` namespace.

  ```shell
  $ kubectl create -n serving-tests secret tls server-certs \
      --key=tls.key --cert=tls.crt
  ```

2. Set env variable `UPSTREAM_TLS_CERT=server-certs` and run the tests.

  ```shell
  $ export UPSTREAM_TLS_CERT=server-certs
  $ go test -race -count=1 -tags=e2e ./test/conformance/ -run "TestIngressConformance/basic"
  ```

3. The backend test server starts running with TLS.

  ```shell
  $ kubectl -n serving-tests logs ingress-conformance-basics-tfpnykaw
  2022/01/27 11:54:14 Server starting on port with TLS 8047
    ...
  ```

Part of https://github.com/knative-sandbox/net-kourier/issues/750
knative-sandbox/net-kourier#761 demonstrates how it works.

/cc @evankanderson @julz @carlisia 