### PR TITLE
Add component label to reduce invocations

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:


### PR DESCRIPTION
# Changes

When we install networking with serving, multiple validating
webhooks are registered.

Previously, the webhooks were configured with just namespace
selectors that are identical. Thus when the config file is updated,
the serving webhook is invoked (which is a noop) and vice-versa
for any serving config maps.

To avoid this, this PR updates the config-network configmap to
include an extra label (`component:networking`) to further
distinguish networking resources from serving resources.

/kind cleanup

Part of https://github.com/knative/serving/issues/12594

**Release Note**

```release-note
Updates config-networking to include an `app.kubernetes.io/component` label to assist with reducing unnecessary webhook invocations
```