### PR TITLE
Add validation for activator-ca and activator-san

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "ddc3250f"
+    knative.dev/example-checksum: "7c86cb6a"
 data:
   _example: |
     ################################
@@ -183,7 +183,7 @@ data:
     activator-ca: ""
 
     # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
-    # It is available only when "activator-ca" is specified.
+    # It must be set when "activator-ca" is specified.
     # Use an empty value to disable the feature (default).
     #
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -447,6 +447,15 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	default:
 		return nil, fmt.Errorf("httpProtocol %s in config-network ConfigMap is not supported", data[HTTPProtocolKey])
 	}
+
+	if nc.ActivatorCA != "" && nc.ActivatorSAN == "" {
+		return nil, fmt.Errorf("%q must be set when %q was set", ActivatorSANKey, ActivatorCAKey)
+	}
+
+	if nc.ActivatorCA == "" && nc.ActivatorSAN != "" {
+		return nil, fmt.Errorf("%q must be set when %q was set", ActivatorCAKey, ActivatorSANKey)
+	}
+
 	return nc, nil
 }
 

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -286,6 +286,31 @@ func TestConfiguration(t *testing.T) {
 			return c
 		}(),
 	}, {
+		name: "network configuration with activator-ca and activator-san",
+		data: map[string]string{
+			ActivatorCAKey:  "test-ca",
+			ActivatorSANKey: "test-san",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.ActivatorCA = "test-ca"
+			c.ActivatorSAN = "test-san"
+			return c
+		}(),
+	}, {
+		name: "network configuration with activator-ca and missing activator-san",
+		data: map[string]string{
+			ActivatorCAKey: "test-ca",
+		},
+		wantErr: true,
+	}, {
+		name: "network configuration with activator-san and missing activator-ca",
+		data: map[string]string{
+			ActivatorCAKey: "test-san",
+		},
+		wantErr: true,
+	}, {
 		name: "legacy keys",
 		data: map[string]string{
 			"ingress.class":         "1",


### PR DESCRIPTION
This is a follow up for https://github.com/knative/networking/pull/608.

This patch adds a validation to disallow `activator-ca` without `activator-san`.
I think we can relax the validation in the future if users want to skip SAN validation
but the initial implementation should be strict.

/cc @evankanderson @ZhiminXiang @carlisia 