### PR TITLE
Add certificates config keys in config-network

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "7c86cb6a"
+    knative.dev/example-checksum: "65b0cddb"
 data:
   _example: |
     ################################
@@ -188,3 +188,35 @@ data:
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
     activator-san: ""
+
+    # The server certificates to serve the TLS traffic from ingress to activator.
+    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    activator-server-certs: ""
+
+    # The CA public certificate used to sign the queue-proxy TLS certificate.
+    # It is specified by the secret name, which has the "ca.crt" data field.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    queue-proxy-ca: ""
+
+    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
+    # It must be set when "queue-proxy-ca" is specified.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    queue-proxy-san: ""
+
+    # The server certificates to serve the TLS traffic from activator to queue-proxy.
+    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    queue-proxy-server-certs: ""

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -196,6 +196,21 @@ const (
 
 	// ActivatorSANKey is the config for the SAN used to validate the activator TLS certificate.
 	ActivatorSANKey = "activator-san"
+
+	// ActivatorServerCertKey is the config for the secret name, which stores certificates
+	// to serve the TLS traffic from ingress to activator.
+	ActivatorServerCertKey = "activator-server-certs"
+
+	// QueueProxyCAKey is the config for the secret name, which stores CA public certificate used
+	// to sign the queue-proxy TLS certificate.
+	QueueProxyCAKey = "queue-proxy-ca"
+
+	// QueueProxySANKey is the config for the SAN used to validate the queue-proxy TLS certificate.
+	QueueProxySANKey = "queue-proxy-san"
+
+	// QueueProxyServerCertKey is the config for the secret name, which stores certificates
+	// to serve the TLS traffic from activator to queue-proxy.
+	QueueProxyServerCertKey = "queue-proxy-server-certs"
 )
 
 // DomainTemplateValues are the available properties people can choose from
@@ -302,6 +317,20 @@ type Config struct {
 	// ActivatorSAN defines the SAN (Subject Alt Name) used to validate the activator TLS certificate.
 	// It is used only when ActivatorCA is specified.
 	ActivatorSAN string
+
+	// ActivatorSererCert defines the secret name of the server certificates to serve the TLS traffic from ingress to activator.
+	ActivatorServerCert string
+
+	// QueueProxyCA defines the secret name of the CA public certificate used to sign the queue-proxy TLS certificate.
+	// The traffic to queue-proxy is not encrypted if QueueProxyCA is empty.
+	QueueProxyCA string
+
+	// QueueProxySAN defines the SAN (Subject Alt Name) used to validate the queue-proxy TLS certificate.
+	// It is used only when QueueProxyCA is specified.
+	QueueProxySAN string
+
+	// QueueProxyServerCert defines the secret name of the server certificates to serve the TLS traffic from activator to queue-proxy.
+	QueueProxyServerCert string
 }
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -359,6 +388,10 @@ func defaultConfig() *Config {
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
 		ActivatorCA:                   "",
 		ActivatorSAN:                  "",
+		ActivatorServerCert:           "",
+		QueueProxyCA:                  "",
+		QueueProxySAN:                 "",
+		QueueProxyServerCert:          "",
 	}
 }
 
@@ -392,6 +425,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsString(DefaultExternalSchemeKey, &nc.DefaultExternalScheme),
 		cm.AsString(ActivatorCAKey, &nc.ActivatorCA),
 		cm.AsString(ActivatorSANKey, &nc.ActivatorSAN),
+		cm.AsString(ActivatorServerCertKey, &nc.ActivatorServerCert),
+		cm.AsString(QueueProxyCAKey, &nc.QueueProxyCA),
+		cm.AsString(QueueProxySANKey, &nc.QueueProxySAN),
+		cm.AsString(QueueProxyServerCertKey, &nc.QueueProxyServerCert),
 		asMode(MeshCompatibilityModeKey, &nc.MeshCompatibilityMode),
 		asLabelSelector(NamespaceWildcardCertSelectorKey, &nc.NamespaceWildcardCertSelector),
 	); err != nil {
@@ -454,6 +491,14 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 	if nc.ActivatorCA == "" && nc.ActivatorSAN != "" {
 		return nil, fmt.Errorf("%q must be set when %q was set", ActivatorCAKey, ActivatorSANKey)
+	}
+
+	if nc.QueueProxyCA != "" && nc.QueueProxySAN == "" {
+		return nil, fmt.Errorf("%q must be set when %q was set", QueueProxySANKey, QueueProxyCAKey)
+	}
+
+	if nc.QueueProxyCA == "" && nc.QueueProxySAN != "" {
+		return nil, fmt.Errorf("%q must be set when %q was set", QueueProxyCAKey, QueueProxySANKey)
 	}
 
 	return nc, nil

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -307,7 +307,32 @@ func TestConfiguration(t *testing.T) {
 	}, {
 		name: "network configuration with activator-san and missing activator-ca",
 		data: map[string]string{
-			ActivatorCAKey: "test-san",
+			ActivatorSANKey: "test-san",
+		},
+		wantErr: true,
+	}, {
+		name: "network configuration with queue-proxy-ca and queue-proxy-san",
+		data: map[string]string{
+			QueueProxyCAKey:  "test-ca",
+			QueueProxySANKey: "test-san",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.QueueProxyCA = "test-ca"
+			c.QueueProxySAN = "test-san"
+			return c
+		}(),
+	}, {
+		name: "network configuration with queue-proxy-ca and missing queue-proxy-san",
+		data: map[string]string{
+			QueueProxyCAKey: "test-ca",
+		},
+		wantErr: true,
+	}, {
+		name: "network configuration with queue-proxy-san and missing queue-proxy-ca",
+		data: map[string]string{
+			QueueProxySANKey: "test-san",
 		},
 		wantErr: true,
 	}, {


### PR DESCRIPTION
This patch adds the following certificate variables:

- `activator-server-certs`
- `queue-proxy-ca`
- `queue-proxy-san`
- `queue-proxy-server-certs`

It is similar to https://github.com/knative/networking/pull/608.

https://github.com/knative/serving/pull/12815 and https://github.com/knative/serving/pull/12770
verified the change.

/cc @evankanderson 
