### PR TITLE
Support `internal-encryption` to deploy internal certificates automatically

### DIFF
--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "95478c0c"
+    knative.dev/example-checksum: "73d96d1b"
 data:
   _example: |
     ################################
@@ -173,7 +173,7 @@ data:
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
 
-    # internal-encryption indicates whether internal trafic is encrypted or not.
+    # internal-encryption indicates whether internal traffic is encrypted or not.
     # If this is "true", the following traffic are encrypted:
     #  - ingress to activator
     #  - ingress to queue-proxy

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "d0b91f80"
+    knative.dev/example-checksum: "95478c0c"
 data:
   _example: |
     ################################
@@ -173,50 +173,12 @@ data:
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
 
-    # The CA public certificate used to sign the activator TLS certificate.
-    # It is specified by the secret name, which has the "ca.crt" data field.
-    # Use an empty value to disable the feature (default).
+    # internal-encryption indicates whether internal trafic is encrypted or not.
+    # If this is "true", the following traffic are encrypted:
+    #  - ingress to activator
+    #  - ingress to queue-proxy
+    #  - activator to queue-proxy
     #
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
-    activator-ca: ""
-
-    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
-    # It must be set when "activator-ca" is specified.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    activator-san: ""
-
-    # The server certificates to serve the TLS traffic from ingress to activator.
-    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    activator-cert-secret: ""
-
-    # The CA public certificate used to sign the queue-proxy TLS certificate.
-    # It is specified by the secret name, which has the "ca.crt" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-ca: ""
-
-    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
-    # It must be set when "queue-proxy-ca" is specified.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-san: ""
-
-    # The server certificates to serve the TLS traffic from activator to queue-proxy.
-    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-cert-secret: ""
+    internal-encryption: "false"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,10 @@ const (
 	// CertManagerCertificateClassName value for specifying Knative's Cert-Manager
 	// Certificate reconciler.
 	CertManagerCertificateClassName = "cert-manager.certificate.networking.knative.dev"
+
+	// ServingInternalCertName is the name of secret contains certificates in serving
+	// system namespace.
+	ServingInternalCertName = "knative-serving-certs"
 )
 
 // Config Keys

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,27 +118,9 @@ const (
 	// hostname for a Route's tag.
 	TagTemplateKey = "tag-template"
 
-	// ActivatorCAKey is the config for the secret name, which stores CA public certificate used
-	// to sign the activator TLS certificate.
-	ActivatorCAKey = "activator-ca"
-
-	// ActivatorSANKey is the config for the SAN used to validate the activator TLS certificate.
-	ActivatorSANKey = "activator-san"
-
-	// ActivatorCertKey is the config for the secret name, which stores certificates
-	// to serve the TLS traffic from ingress to activator.
-	ActivatorCertKey = "activator-cert-secret"
-
-	// QueueProxyCAKey is the config for the secret name, which stores CA public certificate used
-	// to sign the queue-proxy TLS certificate.
-	QueueProxyCAKey = "queue-proxy-ca"
-
-	// QueueProxySANKey is the config for the SAN used to validate the queue-proxy TLS certificate.
-	QueueProxySANKey = "queue-proxy-san"
-
-	// QueueProxyCertKey is the config for the secret name, which stores certificates
-	// to serve the TLS traffic from activator to queue-proxy.
-	QueueProxyCertKey = "queue-proxy-cert-secret"
+	// InternalEncryptionKey is the name of the configuration whether
+	// internal trafic is encrypted or not.
+	InternalEncryptionKey = "internal-encryption"
 )
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -265,27 +247,8 @@ type Config struct {
 	// not enabled. Defaults to "http".
 	DefaultExternalScheme string
 
-	// ActivatorCA defines the secret name of the CA public certificate used to sign the activator TLS certificate.
-	// The traffic is not encrypted if ActivatorCA is empty.
-	ActivatorCA string
-
-	// ActivatorSAN defines the SAN (Subject Alt Name) used to validate the activator TLS certificate.
-	// It is used only when ActivatorCA is specified.
-	ActivatorSAN string
-
-	// ActivatorCertSecret defines the secret name of the server certificates to serve the TLS traffic from ingress to activator.
-	ActivatorCertSecret string
-
-	// QueueProxyCA defines the secret name of the CA public certificate used to sign the queue-proxy TLS certificate.
-	// The traffic to queue-proxy is not encrypted if QueueProxyCA is empty.
-	QueueProxyCA string
-
-	// QueueProxySAN defines the SAN (Subject Alt Name) used to validate the queue-proxy TLS certificate.
-	// It is used only when QueueProxyCA is specified.
-	QueueProxySAN string
-
-	// QueueProxyCertSecret defines the secret name of the server certificates to serve the TLS traffic from activator to queue-proxy.
-	QueueProxyCertSecret string
+	// DefaultExternal specifies whether internal trafic is encrypted or not.
+	InternalEncryption bool
 }
 
 func defaultConfig() *Config {
@@ -300,12 +263,7 @@ func defaultConfig() *Config {
 		AutocreateClusterDomainClaims: false,
 		DefaultExternalScheme:         "http",
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
-		ActivatorCA:                   "",
-		ActivatorSAN:                  "",
-		ActivatorCertSecret:           "",
-		QueueProxyCA:                  "",
-		QueueProxySAN:                 "",
-		QueueProxyCertSecret:          "",
+		InternalEncryption:            false,
 	}
 }
 
@@ -332,12 +290,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsBool(AutocreateClusterDomainClaimsKey, &nc.AutocreateClusterDomainClaims),
 		cm.AsBool(EnableMeshPodAddressabilityKey, &nc.EnableMeshPodAddressability),
 		cm.AsString(DefaultExternalSchemeKey, &nc.DefaultExternalScheme),
-		cm.AsString(ActivatorCAKey, &nc.ActivatorCA),
-		cm.AsString(ActivatorSANKey, &nc.ActivatorSAN),
-		cm.AsString(ActivatorCertKey, &nc.ActivatorCertSecret),
-		cm.AsString(QueueProxyCAKey, &nc.QueueProxyCA),
-		cm.AsString(QueueProxySANKey, &nc.QueueProxySAN),
-		cm.AsString(QueueProxyCertKey, &nc.QueueProxyCertSecret),
+		cm.AsBool(InternalEncryptionKey, &nc.InternalEncryption),
 		asMode(MeshCompatibilityModeKey, &nc.MeshCompatibilityMode),
 		asLabelSelector(NamespaceWildcardCertSelectorKey, &nc.NamespaceWildcardCertSelector),
 	); err != nil {
@@ -392,22 +345,6 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		nc.HTTPProtocol = HTTPRedirected
 	default:
 		return nil, fmt.Errorf("httpProtocol %s in config-network ConfigMap is not supported", data[HTTPProtocolKey])
-	}
-
-	if nc.ActivatorCA != "" && nc.ActivatorSAN == "" {
-		return nil, fmt.Errorf("%q must be set when %q was set", ActivatorSANKey, ActivatorCAKey)
-	}
-
-	if nc.ActivatorCA == "" && nc.ActivatorSAN != "" {
-		return nil, fmt.Errorf("%q must be set when %q was set", ActivatorCAKey, ActivatorSANKey)
-	}
-
-	if nc.QueueProxyCA != "" && nc.QueueProxySAN == "" {
-		return nil, fmt.Errorf("%q must be set when %q was set", QueueProxySANKey, QueueProxyCAKey)
-	}
-
-	if nc.QueueProxyCA == "" && nc.QueueProxySAN != "" {
-		return nil, fmt.Errorf("%q must be set when %q was set", QueueProxyCAKey, QueueProxySANKey)
 	}
 
 	return nc, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,7 @@ const (
 	TagTemplateKey = "tag-template"
 
 	// InternalEncryptionKey is the name of the configuration whether
-	// internal trafic is encrypted or not.
+	// internal traffic is encrypted or not.
 	InternalEncryptionKey = "internal-encryption"
 )
 
@@ -251,7 +251,7 @@ type Config struct {
 	// not enabled. Defaults to "http".
 	DefaultExternalScheme string
 
-	// DefaultExternal specifies whether internal trafic is encrypted or not.
+	// DefaultExternal specifies whether internal traffic is encrypted or not.
 	InternalEncryption bool
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -279,53 +279,14 @@ func TestConfiguration(t *testing.T) {
 	}, {
 		name: "network configuration with activator-ca and activator-san",
 		data: map[string]string{
-			ActivatorCAKey:  "test-ca",
-			ActivatorSANKey: "test-san",
+			InternalEncryptionKey: "true",
 		},
 		wantErr: false,
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.ActivatorCA = "test-ca"
-			c.ActivatorSAN = "test-san"
+			c.InternalEncryption = true
 			return c
 		}(),
-	}, {
-		name: "network configuration with activator-ca and missing activator-san",
-		data: map[string]string{
-			ActivatorCAKey: "test-ca",
-		},
-		wantErr: true,
-	}, {
-		name: "network configuration with activator-san and missing activator-ca",
-		data: map[string]string{
-			ActivatorSANKey: "test-san",
-		},
-		wantErr: true,
-	}, {
-		name: "network configuration with queue-proxy-ca and queue-proxy-san",
-		data: map[string]string{
-			QueueProxyCAKey:  "test-ca",
-			QueueProxySANKey: "test-san",
-		},
-		wantErr: false,
-		wantConfig: func() *Config {
-			c := defaultConfig()
-			c.QueueProxyCA = "test-ca"
-			c.QueueProxySAN = "test-san"
-			return c
-		}(),
-	}, {
-		name: "network configuration with queue-proxy-ca and missing queue-proxy-san",
-		data: map[string]string{
-			QueueProxyCAKey: "test-ca",
-		},
-		wantErr: true,
-	}, {
-		name: "network configuration with queue-proxy-san and missing queue-proxy-ca",
-		data: map[string]string{
-			QueueProxySANKey: "test-san",
-		},
-		wantErr: true,
 	}, {
 		name: "legacy keys",
 		data: map[string]string{

--- a/pkg/deprecated_config.go
+++ b/pkg/deprecated_config.go
@@ -123,40 +123,6 @@ const (
 	//
 	// Deprecated: use knative.dev/networking/pkg/config.DefaultExternalSchemeKey
 	DefaultExternalSchemeKey = config.DefaultExternalSchemeKey
-
-	// ActivatorCAKey is the config for the secret name, which stores CA public certificate used
-	// to sign the activator TLS certificate.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.ActivatorCAKey
-	ActivatorCAKey = config.ActivatorCAKey
-
-	// ActivatorSANKey is the config for the SAN used to validate the activator TLS certificate.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.ActivatorSANKey
-	ActivatorSANKey = config.ActivatorSANKey
-
-	// ActivatorCertKey is the config for the secret name, which stores certificates
-	// to serve the TLS traffic from ingress to activator.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.ActivatorCertKey
-	ActivatorCertKey = config.ActivatorCertKey
-
-	// QueueProxyCAKey is the config for the secret name, which stores CA public certificate used
-	// to sign the queue-proxy TLS certificate.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.QueueProxyCAKey
-	QueueProxyCAKey = config.QueueProxyCAKey
-
-	// QueueProxySANKey is the config for the SAN used to validate the queue-proxy TLS certificate.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.QueueProxySANKey
-	QueueProxySANKey = config.QueueProxySANKey
-
-	// QueueProxyCertKey is the config for the secret name, which stores certificates
-	// to serve the TLS traffic from activator to queue-proxy.
-	//
-	// Deprecated: use knative.dev/networking/pkg/config.QueueProxyCertKey
-	QueueProxyCertKey = config.QueueProxyCertKey
 )
 
 // DomainTemplateValues are the available properties people can choose from


### PR DESCRIPTION
Currently users have to deploy certificates manually with several options such as
`activator-san`, `activator-ca`, `queue-proxy-ca` etc.

Such deployment and management of the certificates is a big burden for users.

Hence, this patch supports `internal-encryption` config to deploy
internal certificates automatically.

https://github.com/knative-sandbox/net-kourier/pull/855 and https://github.com/knative/serving/pull/13005 demonstrated this change.
