### PR TITLE
Bump Go version to 1.18 for CI

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -24,7 +24,7 @@ jobs:
     name: knative-${{ matrix.repository }}
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest]
         repository: [serving]
 
@@ -66,7 +66,7 @@ jobs:
     name: knative-sandbox-${{ matrix.repository }}
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest]
         repository: [net-istio, net-contour, net-kourier, net-certmanager, net-http01]
 

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        go get github.com/google/go-licenses
+        go install github.com/google/go-licenses@latest
 
     - name: Checkout Upstream
       uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        go get github.com/google/go-licenses
+        go install github.com/google/go-licenses@latest
 
     - name: Checkout Upstream
       uses: actions/checkout@v2


### PR DESCRIPTION
Same fix with https://github.com/knative-sandbox/net-kourier/pull/881.