### PR TITLE
remove defunct markdown linting variable

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,10 +21,6 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
-# Markdown linting failures don't show up properly in Gubernator resulting
-# in a net-negative contributor experience.
-export DISABLE_MD_LINTING=1
-
 source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh
 
 # TODO(mattmoor): integration tests


### PR DESCRIPTION
Addresses https://github.com/knative/hack/issues/200

Removes a dead variable in the presubmit tests related to markdown linting