### PR TITLE
fix http01 conformance tests

### DIFF
--- a/test/conformance/certificate/http01/certificate.go
+++ b/test/conformance/certificate/http01/certificate.go
@@ -32,8 +32,8 @@ func TestHTTP01Challenge(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	certDomains := [][]string{
-		{subDomain + ".knative.dev"},
-		{subDomain + "2.knative.dev", subDomain + "3.knative.dev"},
+		{subDomain + ".knative-test.dev"},
+		{subDomain + "2.knative-test.dev", subDomain + "3.knative-test.dev"},
 	}
 
 	for _, domains := range certDomains {

--- a/test/conformance/certificate/http01/certificate.go
+++ b/test/conformance/certificate/http01/certificate.go
@@ -32,8 +32,8 @@ func TestHTTP01Challenge(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	certDomains := [][]string{
-		{subDomain + ".example.com"},
-		{subDomain + "2.example.com", subDomain + "3.example.com"},
+		{subDomain + ".knative.dev"},
+		{subDomain + "2.knative.dev", subDomain + "3.knative.dev"},
 	}
 
 	for _, domains := range certDomains {


### PR DESCRIPTION
LetsEncrypt no longer allows us to order certs for `example.com` it returns a HTTP 400 Bad Request.

This breaks the conformance tests as it expects an 'order' to be submitted (though it doesn't expect it to succeed)