### PR TITLE
adjust domain validation in kcert

### DIFF
--- a/pkg/apis/networking/v1alpha1/certificate_validation.go
+++ b/pkg/apis/networking/v1alpha1/certificate_validation.go
@@ -50,14 +50,14 @@ func (spec *CertificateSpec) Validate(ctx context.Context) (all *apis.FieldError
 		suffix := "." + spec.Domain
 		valid := false
 		for _, dnsName := range spec.DNSNames {
-			if strings.HasSuffix(dnsName, suffix) {
+			if strings.HasSuffix(dnsName, suffix) || dnsName == spec.Domain {
 				valid = true
 				break
 			}
 		}
 
 		if !valid {
-			all = all.Also(apis.ErrInvalidValue("domain", "domain must be a suffix of at least one entry in dnsNames"))
+			all = all.Also(apis.ErrInvalidValue("domain", "domain must be a suffix of, or match exactly, at least one entry in dnsNames"))
 		}
 	}
 

--- a/pkg/apis/networking/v1alpha1/certificate_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_validation_test.go
@@ -45,6 +45,14 @@ func TestCertificateSpecValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "valid-domain-equals-dnsnames",
+		cs: &CertificateSpec{
+			DNSNames:   []string{"host.example"},
+			Domain:     "host.example",
+			SecretName: "secret",
+		},
+		want: nil,
+	}, {
 		name: "missing-dnsnames",
 		cs: &CertificateSpec{
 			DNSNames:   []string{},
@@ -75,7 +83,7 @@ func TestCertificateSpecValidation(t *testing.T) {
 			Domain:     "example",
 			SecretName: "secret",
 		},
-		want: apis.ErrInvalidValue("domain", "domain must be a suffix of at least one entry in dnsNames"),
+		want: apis.ErrInvalidValue("domain", "domain must be a suffix of, or match exactly, at least one entry in dnsNames"),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
* don't add . to the domain

<!-- Thanks for sending a pull request! -->

# Changes


- :bug: Fix bug
- Initial PR (https://github.com/knative/networking/pull/747) only checked if "." + domain was a suffix of the dnsnames entries. This would fail is the dnsName entry matched the domain exactly
- change to allow the domain to equal an entry in the dnsnames
- Bug discovered while working on https://github.com/knative/serving/pull/13569#issuecomment-1387374733

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
N/A
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
