### PR TITLE
Assert all the expected DNSNames are part of the HTTP01 challenge

### DIFF
--- a/test/conformance/certificate/http01/certificate.go
+++ b/test/conformance/certificate/http01/certificate.go
@@ -41,7 +41,22 @@ func TestHTTP01Challenge(t *testing.T) {
 
 		if err := utils.WaitForCertificateState(ctx, clients.NetworkingClient, cert.Name,
 			func(c *v1alpha1.Certificate) (bool, error) {
-				return len(c.Status.HTTP01Challenges) == len(c.Spec.DNSNames), nil
+				for _, dnsName := range c.Spec.DNSNames {
+					found := false
+
+					for _, challenge := range c.Status.HTTP01Challenges {
+						if challenge.URL.Host == dnsName {
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						return false, nil
+					}
+				}
+
+				return true, nil
 			},
 			t.Name()); err != nil {
 			t.Fatal("failed to wait for HTTP01 challenges:", err)


### PR DESCRIPTION
This allows us to include additional domains as part of the
challenge (this is needed for long URL domains workaround where we add a shorter commonName)


Unblocks: https://github.com/knative-sandbox/net-certmanager/pull/478