### PR TITLE
Mark `NewConfigFromConfigMap()` as Deprecated in `deprecated_config.go`

### DIFF
--- a/pkg/deprecated_config.go
+++ b/pkg/deprecated_config.go
@@ -203,6 +203,8 @@ const (
 )
 
 // NewConfigFromConfigMap creates a Config from the supplied ConfigMap
+//
+// Deprecated: Use knative.dev/networking/pkg/config/NewConfigFromMap
 func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 	return NewConfigFromMap(configMap.Data)
 }


### PR DESCRIPTION
As per title, `NewConfigFromConfigMap()` is not deprecated even in `deprecated_config.go`
so there is no warning message.

This patch adds the `Deprecated:` tag.

/cc @dprotaso 