### PR TITLE
:broom: Bump Go version in github action to 1.19

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -36,10 +36,10 @@ jobs:
         - knative-sandbox/net-http01
 
     steps:
-    - name: Set up Go 1.18.x
+    - name: Set up Go 1.19.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
As per title this patch bumps Go version in github action to 1.19.

Currently unit test always fails https://github.com/knative/networking/actions/runs/4725229802/jobs/8383377259#step:19:139, as https://pkg.go.dev/crypto/x509#CertPool.Equal `CertPool.Equal` was added in Go 1.19.

