### PR TITLE
Backward compatibility for InternalEncryption

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -405,6 +405,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	case "", string(TrustDisabled):
 		// If DataplaneTrus is not set in the config-network, default is already
 		// set to TrustDisabled.
+		if nc.InternalEncryption {
+			// Backward compatibility
+			nc.DataplaneTrust = TrustMinimal
+		}
 	case string(TrustMinimal):
 		nc.DataplaneTrust = TrustMinimal
 	case string(TrustEnabled):

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -285,6 +285,7 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.InternalEncryption = true
+			c.DataplaneTrust = TrustMinimal
 			return c
 		}(),
 	}, {


### PR DESCRIPTION
Ensure that if someone uses the deprecated InternalEncryption, we use Dataplane-trust=Minimal as a minimum. 
InternalEncryption is deprecated but will take time to remove from dependencies
