### PR TITLE
Ensure old revision stays Unreachable after Knative Service update

### DIFF
--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -90,12 +90,9 @@ func (sss *ServerlessServiceStatus) MarkEndpointsNotReady(reason string) {
 		"K8s Service is not ready")
 }
 
-// IsReady returns true if the Status condition Ready
-// is true and the latest spec has been observed.
+// IsReady returns true if the Status condition Ready is true
 func (ss *ServerlessService) IsReady() bool {
-	sss := ss.Status
-	return sss.ObservedGeneration == ss.Generation &&
-		sss.GetCondition(ServerlessServiceConditionReady).IsTrue()
+	return ss.Status.GetCondition(ServerlessServiceConditionReady).IsTrue()
 }
 
 // ProxyFor returns how long it has been since Activator was moved


### PR DESCRIPTION
# Changes

Fixes https://github.com/knative/serving/issues/14115 by changing how `IsReady` is implemented.

Currently, the [`IsReady` function of the ServerlessService](https://github.com/knative/serving/blob/v0.27.2/vendor/knative.dev/networking/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go#L95) which is returning false if the generation is different in metadata and status.

Due to it temporarily not being ready, the PodAutoscaler is set to SKSReady=Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/reconciler/autoscaling/kpa/kpa.go#L174).

The PodAutoscaler then goes Ready=False because SKSReady is part of Ready [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go#L34-L38).

The revision inherits the PodAutoscaler status and sets Active=Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/serving/v1/revision_lifecycle.go#L172-L202).

This causes the PodAutoscaler's Reachability to be set to Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/reconciler/revision/resources/pa.go#L60).

Once the PodAutoscaler is not anymore marked as unreachable, the scaling boundary will be set to the min value from the annotation again [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go#L90-L95). This will cause a revision that is being not needed anymore to scale up again for a short moment which causes additional pods.

I am changing the `IsReady` of the ServerlessService to only check the condition. This fixes the problem and I have not seen negative impact. Though, it undos the work of [IsReady should take ObservedGeneration into account #8004](https://github.com/knative/serving/issues/8004) which sounds to me as if it tried to resolve an abstract issue while I here have a real one. Alternative could be to leave `IsReady` unchanged und look at the condition directly in kpa.go.

I need somebody with experience in this area to carefully assess if there are side-effects.

/kind bug

**Release Note**

```release-note
An Unreachable revision is now not anymore causing additional pods to get created while it is scaled down to 0.
```

**Docs**

None