### PR TITLE
Network Config Changes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"text/template"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/lru"
 	cm "knative.dev/pkg/configmap"
@@ -319,6 +320,14 @@ func defaultConfig() *Config {
 		DataplaneTrust:                TrustDisabled,
 		ControlplaneTrust:             TrustDisabled,
 	}
+}
+
+// NewConfigFromConfigMap returns a Config for the given configmap
+func NewConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
+	if config == nil {
+		return NewConfigFromMap(nil)
+	}
+	return NewConfigFromMap(config.Data)
 }
 
 // NewConfigFromMap creates a Config from the supplied data.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -436,6 +436,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	return nc, nil
 }
 
+// InternalTLSEnabled returns whether or not dataplane-trust is disabled
+func (c *Config) InternalTLSEnabled() bool {
+	return c.DataplaneTrust != TrustDisabled
+}
+
 // GetDomainTemplate returns the golang Template from the config map
 // or panics (the value is validated during CM validation and at
 // this point guaranteed to be parseable).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Add new features

- Adds a function to quickly tell if InternalTLS is enabled ( a common thing to do now that we've added the dataplane-trust flag)
- Adds a function to create a config from a configmap. I've seen this some places and not on others. I'm not sure if this is a pattern we are trying to get away from?
-
-



/kind enhancement



<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
N/A
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
