### PR TITLE
Improve InternalTLSEnabled util function

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,7 +134,7 @@ const (
 	// hostname for a Route's tag.
 	TagTemplateKey = "tag-template"
 
-	// InternalEncryptionKey is deprecated and replaced by InternalDataplaneTrustKey and internal-controlplane-trust
+	// InternalEncryptionKey is deprecated and replaced by InternalDataplaneTrustKey and ControlplaneTrustKey.
 	// InternalEncryptionKey is the name of the configuration whether
 	// internal traffic is encrypted or not.
 	InternalEncryptionKey = "internal-encryption"
@@ -445,9 +445,21 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	return nc, nil
 }
 
-// InternalTLSEnabled returns whether or not dataplane-trust is disabled
-func (c *Config) InternalTLSEnabled() bool {
-	return c.DataplaneTrust != TrustDisabled
+// DataplaneTLSEnabled returns whether or not dataplane-trust is enabled.
+func (c *Config) DataplaneTLSEnabled() bool {
+	return tlsEnabled(c.DataplaneTrust)
+}
+
+// ControlplaneTLSEnabled returns whether or not controlane-trust is enabled.
+func (c *Config) ControlplaneTLSEnabled() bool {
+	return tlsEnabled(c.ControlplaneTrust)
+}
+
+func tlsEnabled(trust Trust) bool {
+	return trust == TrustMinimal ||
+		trust == TrustEnabled ||
+		trust == TrustMutual ||
+		trust == TrustIdentity
 }
 
 // GetDomainTemplate returns the golang Template from the config map

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -445,14 +445,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	return nc, nil
 }
 
-// DataplaneTLSEnabled returns whether or not dataplane-trust is enabled.
-func (c *Config) DataplaneTLSEnabled() bool {
+// InternalTLSEnabled returns whether or not InternalEncyrption is enabled.
+// Currently only DataplaneTrust is considered.
+func (c *Config) InternalTLSEnabled() bool {
 	return tlsEnabled(c.DataplaneTrust)
-}
-
-// ControlplaneTLSEnabled returns whether or not controlane-trust is enabled.
-func (c *Config) ControlplaneTLSEnabled() bool {
-	return tlsEnabled(c.ControlplaneTrust)
 }
 
 func tlsEnabled(trust Trust) bool {


### PR DESCRIPTION
Currently `InternalTLSEnabled()` has two issues such as:

* `true` is returned when `dataplane-trust` is not configured. (The current default is `disabled`.)
* ~`controlplane-trust` is not considered.~

This patch improves these issues.

/kind enhancement

**Release Note**

```release-note
NONE
```