### PR TITLE
Align the encryption flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the Knative Ingress and Certificate CRDs, as well as
 their conformance tests. These are our extension points to plugin different
 Ingress plugins (Ambassador, Contour, Gloo, Istio, Kong and Kourier), as well as
-different AutoTLS plugins (CertManager and Knative's own HTTP01 challenge
+different ExternalDomainTLS plugins (CertManager and Knative's own HTTP01 challenge
 solver).
 
 # Knative Ingress aka KIngress

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "cfad3b9a"
+    knative.dev/example-checksum: "8cbfa515"
 data:
   _example: |
     ################################
@@ -73,7 +73,7 @@ data:
     #   namespace-wildcard-cert-selector: {}
     #
     # Useful labels include the "kubernetes.io/metadata.name" label to
-    # avoid provisioning a certifcate for the "kube-system" namespaces.
+    # avoid provisioning a certificate for the "kube-system" namespaces.
     # Use the following selector to match pre-1.0 behavior of using
     # "networking.knative.dev/disableWildcardCert" to exclude namespaces:
     #
@@ -114,16 +114,45 @@ data:
     # domain-template above to determine the full URL for the tag.
     tag-template: "{{.Tag}}-{{.Name}}"
 
-    # Controls whether TLS certificates are automatically provisioned and
-    # installed in the Knative ingress to terminate external TLS connection.
-    # 1. Enabled: enabling auto-TLS feature.
-    # 2. Disabled: disabling auto-TLS feature.
+    # auto-tls is deprecated and replaced by external-domain-tls
     auto-tls: "Disabled"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster external domains (like: app.example.com)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster external domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster external domains.
+    external-domain-tls: "Disabled"
+
+    # Controls weather TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster local domains (like: app.namespace.svc.cluster.local)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    cluster-local-domain-tls: "Disabled"
+
+    # internal-encryption is deprecated and replaced by knative-internal-tls
+    internal-encryption: "false"
+
+    # knative-internal-tls controls weather TLS encryption is used for connections between
+    # the internal components of Knative:
+    # - ingress to activator
+    # - ingress to queue-proxy
+    # - activator to queue-proxy
+    #
+    # Possible values for this flag are:
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    knative-internal-tls: "Disabled"
 
     # Controls the behavior of the HTTP endpoint for the Knative ingress.
     # It requires auto-tls to be enabled.
-    # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
-    # 2. Redirected: The Knative ingress will send a 301 redirect for all
+    # - Enabled: The Knative ingress will be able to serve HTTP connection.
+    # - Redirected: The Knative ingress will send a 301 redirect for all
     # http connections, asking the clients to use HTTPS.
     #
     # "Disabled" option is deprecated.
@@ -172,35 +201,3 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
-
-    # internal-encryption is deprecated and replaced by dataplane-trust and controlplane-trust
-    # internal-encryption indicates whether internal traffic is encrypted or not.
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    internal-encryption: "false"
-
-    # dataplane-trust indicates the level of trust established in the knative data-plane.
-    # dataplane-trust = "disabled" (the default) - uses no encryption for internal data plane traffic
-    # Using any other value ensures that the following traffic is encrypted using TLS:
-    #  - ingress to activator
-    #  - ingress to queue-proxy
-    #  - activator to queue-proxy
-    #
-    # dataplane-trust = "minimal" ensures data messages are encrypted, Kingress authenticate that the receiver is a Ksvc
-    # dataplane-trust = "enabled" same as "minimal" and in addition, Kingress authenticate that Ksvc is at the correct namespace
-    # dataplane-trust = "mutual" same as "enabled" and in addition, Ksvc authenticate that the messages come from the Kingress
-    # dataplane-trust = "identity" same as "mutual" with Kingress adding a trusted sender identity to the message
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing for now. Use with caution.
-    dataplane-trust: "disabled"
-
-    # controlplane-trust indicates the level of trust established in the knative control-plane.
-    # controlplane-trust = "disabled" (the default) - uses no encryption for internal control plane traffic
-    # Using any other value ensures that control traffic is encrypted using TLS.
-    #
-    # controlplane-trust = "enabled" ensures control messages are encrypted using TLS (client authenticate the server)
-    # controlplane-trust = "mutual" ensures control messages are encrypted using mTLS (client and server authenticate each other)
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing for now. Use with caution.
-    controlplane-trust: "disabled"

--- a/config/config-network.yaml
+++ b/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "8cbfa515"
+    knative.dev/example-checksum: "b2698fe8"
 data:
   _example: |
     ################################
@@ -133,10 +133,10 @@ data:
     #       for now. Use with caution.
     cluster-local-domain-tls: "Disabled"
 
-    # internal-encryption is deprecated and replaced by knative-internal-tls
+    # internal-encryption is deprecated and replaced by system-internal-tls
     internal-encryption: "false"
 
-    # knative-internal-tls controls weather TLS encryption is used for connections between
+    # system-internal-tls controls weather TLS encryption is used for connections between
     # the internal components of Knative:
     # - ingress to activator
     # - ingress to queue-proxy
@@ -147,7 +147,7 @@ data:
     # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
-    knative-internal-tls: "Disabled"
+    system-internal-tls: "Disabled"
 
     # Controls the behavior of the HTTP endpoint for the Knative ingress.
     # It requires auto-tls to be enabled.

--- a/pkg/apis/networking/metadata_validation.go
+++ b/pkg/apis/networking/metadata_validation.go
@@ -29,6 +29,7 @@ var (
 		IngressClassAnnotationKey,
 		CertificateClassAnnotationKey,
 		DisableAutoTLSAnnotationKey,
+		DisableExternalDomainTLSAnnotationKey,
 		HTTPOptionAnnotationKey,
 
 		IngressClassAnnotationAltKey,

--- a/pkg/apis/networking/metadata_validation_test.go
+++ b/pkg/apis/networking/metadata_validation_test.go
@@ -45,6 +45,11 @@ func TestValidateObjectMetadata(t *testing.T) {
 			DisableAutoTLSAnnotationAltKey: "true",
 		},
 	}, {
+		name: "valid disable external-domain-tls annotation key",
+		annotations: map[string]string{
+			DisableExternalDomainTLSAnnotationKey: "true",
+		},
+	}, {
 		name: "valid certificate class annotation key",
 		annotations: map[string]string{
 			CertificateClassAnnotationKey:    "certificate.class",

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -70,10 +70,16 @@ const (
 
 	// DisableAutoTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
 	// to indicate that AutoTLS should not be enabled for it.
+	// Deprecated: use DisableExternalDomainTLSAnnotationKey instead.
 	DisableAutoTLSAnnotationKey = PublicGroupName + "/disableAutoTLS"
 
 	// DisableAutoTLSAnnotationAltKey is an alternative casing to DisableAutoTLSAnnotationKey
+	// Deprecated: use DisableExternalDomainTLSAnnotationKey instead.
 	DisableAutoTLSAnnotationAltKey = PublicGroupName + "/disable-auto-tls"
+
+	// DisableExternalDomainTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
+	// to indicate that external-domain-tls should not be enabled for it.
+	DisableExternalDomainTLSAnnotationKey = PublicGroupName + "/disable-external-domain-tls"
 
 	// HTTPOptionAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
 	// to indicate the HTTP option of it.
@@ -130,9 +136,21 @@ var (
 		CertificateClassAnnotationAltKey,
 	}
 
+	// Deprecated: use DisableExternalDomainTLSAnnotation instead.
 	DisableAutoTLSAnnotation = kmap.KeyPriority{
 		DisableAutoTLSAnnotationKey,
 		DisableAutoTLSAnnotationAltKey,
+
+		// backward compatibility
+		DisableExternalDomainTLSAnnotationKey,
+	}
+
+	DisableExternalDomainTLSAnnotation = kmap.KeyPriority{
+		// backward compatibility
+		DisableAutoTLSAnnotationKey,
+		DisableAutoTLSAnnotationAltKey,
+
+		DisableExternalDomainTLSAnnotationKey,
 	}
 
 	HTTPProtocolAnnotation = kmap.KeyPriority{
@@ -153,6 +171,11 @@ func GetHTTPProtocol(annotations map[string]string) (val string) {
 	return HTTPProtocolAnnotation.Value(annotations)
 }
 
+// Deprecated: use GetDisableExternalDomainTLS instead.
 func GetDisableAutoTLS(annotations map[string]string) (val string) {
 	return DisableAutoTLSAnnotation.Value(annotations)
+}
+
+func GetDisableExternalDomainTLS(annotations map[string]string) (val string) {
+	return DisableExternalDomainTLSAnnotation.Value(annotations)
 }

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -137,13 +137,7 @@ var (
 	}
 
 	// Deprecated: use DisableExternalDomainTLSAnnotation instead.
-	DisableAutoTLSAnnotation = kmap.KeyPriority{
-		DisableAutoTLSAnnotationKey,
-		DisableAutoTLSAnnotationAltKey,
-
-		// backward compatibility
-		DisableExternalDomainTLSAnnotationKey,
-	}
+	DisableAutoTLSAnnotation = DisableExternalDomainTLSAnnotation
 
 	DisableExternalDomainTLSAnnotation = kmap.KeyPriority{
 		// backward compatibility
@@ -172,9 +166,7 @@ func GetHTTPProtocol(annotations map[string]string) (val string) {
 }
 
 // Deprecated: use GetDisableExternalDomainTLS instead.
-func GetDisableAutoTLS(annotations map[string]string) (val string) {
-	return DisableAutoTLSAnnotation.Value(annotations)
-}
+var GetDisableAutoTLS = GetDisableExternalDomainTLS
 
 func GetDisableExternalDomainTLS(annotations map[string]string) (val string) {
 	return DisableExternalDomainTLSAnnotation.Value(annotations)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,7 +92,16 @@ const (
 
 	// AutoTLSKey is the name of the configuration entry
 	// that specifies enabling auto-TLS or not.
+	// Deprecated: please use ExternalDomainTLSKey.
 	AutoTLSKey = "auto-tls"
+
+	// ExternalDomainTLSKey is the name of the configuration entry
+	// that specifies if external-domain-tls is enabled or not.
+	ExternalDomainTLSKey = "external-domain-tls"
+
+	// ClusterLocalDomainTLSKey is the name of the configuration entry
+	// that specifies if cluster-local-domain-tls is enabled or not.
+	ClusterLocalDomainTLSKey = "cluster-local-domain-tls"
 
 	// DefaultCertificateClassKey is the name of the configuration entry
 	// that specifies the default Certificate.
@@ -134,39 +143,26 @@ const (
 	// hostname for a Route's tag.
 	TagTemplateKey = "tag-template"
 
-	// InternalEncryptionKey is deprecated and replaced by InternalDataplaneTrustKey and ControlplaneTrustKey.
 	// InternalEncryptionKey is the name of the configuration whether
 	// internal traffic is encrypted or not.
+	// Deprecated: please use KnativeInternalTLSKey.
 	InternalEncryptionKey = "internal-encryption"
 
-	// DataplaneTrustKey is the name of the configuration entry
-	// defining the level of trust used for data plane traffic.
-	DataplaneTrustKey = "dataplane-trust"
-
-	// ControlplaneTrustKey is the name of the configuration entry
-	// defining the level of trust used for control plane traffic.
-	ControlplaneTrustKey = "controlplane-trust"
+	// KnativeInternalTLSKey is the name of the configuration whether
+	// knative internal traffic is encrypted or not.
+	KnativeInternalTLSKey = "knative-internal-tls"
 )
 
-// HTTPProtocol indicates a type of HTTP endpoint behavior
-// that Knative ingress could take.
-type Trust string
+// EncryptionConfig indicates the encryption configuration
+// used for TLS connections.
+type EncryptionConfig string
 
 const (
-	// TrustDisabled - TLS not used
-	TrustDisabled Trust = "disabled"
+	// EncryptionDisabled - TLS not used.
+	EncryptionDisabled EncryptionConfig = "disabled"
 
-	// TrustMinimal - TLS used. We verify that the server is using Knative certificates
-	TrustMinimal Trust = "minimal"
-
-	// TrustEnabled - TLS used. We verify that the server is using Knative certificates of the right namespace
-	TrustEnabled Trust = "enabled"
-
-	// TrustMutual - same as TrustEnabled and we also verify the identity of the client.
-	TrustMutual Trust = "mutual"
-
-	// TrustIdentity - same as TrustMutual and we also add a trusted sender identity to the message.
-	TrustIdentity Trust = "identity"
+	// EncryptionEnabled - TLS used. The client verifies the servers certificate.
+	EncryptionEnabled EncryptionConfig = "enabled"
 )
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior
@@ -244,7 +240,11 @@ type Config struct {
 	TagTemplate string
 
 	// AutoTLS specifies if auto-TLS is enabled or not.
+	// Deprecated: please use ExternalDomainTLS instead.
 	AutoTLS bool
+
+	// ExternalDomainTLS specifies if external-domain-tls is enabled or not.
+	ExternalDomainTLS bool
 
 	// HTTPProtocol specifics the behavior of HTTP endpoint of Knative
 	// ingress.
@@ -293,15 +293,15 @@ type Config struct {
 	// not enabled. Defaults to "http".
 	DefaultExternalScheme string
 
-	// Deprecated - replaced with InternalDataplaneTrust and InternalControlplaneTrust
 	// InternalEncryption specifies whether internal traffic is encrypted or not.
+	// Deprecated: please use KnativeInternalTLSKey instead.
 	InternalEncryption bool
 
-	// DataplaneTrust specifies the level of trust used for date plane.
-	DataplaneTrust Trust
+	// KnativeInternalTLS specifies whether knative internal traffic is encrypted or not.
+	KnativeInternalTLS EncryptionConfig
 
-	// ControlplaneTrust specifies the level of trust used for control plane.
-	ControlplaneTrust Trust
+	// ClusterLocalDomainTLS specifies whether cluster-local traffic is encrypted or not.
+	ClusterLocalDomainTLS EncryptionConfig
 }
 
 func defaultConfig() *Config {
@@ -311,14 +311,15 @@ func defaultConfig() *Config {
 		DomainTemplate:                DefaultDomainTemplate,
 		TagTemplate:                   DefaultTagTemplate,
 		AutoTLS:                       false,
+		ExternalDomainTLS:             false,
 		NamespaceWildcardCertSelector: nil,
 		HTTPProtocol:                  HTTPEnabled,
 		AutocreateClusterDomainClaims: false,
 		DefaultExternalScheme:         "http",
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
 		InternalEncryption:            false,
-		DataplaneTrust:                TrustDisabled,
-		ControlplaneTrust:             TrustDisabled,
+		KnativeInternalTLS:            EncryptionDisabled,
+		ClusterLocalDomainTLS:         EncryptionDisabled,
 	}
 }
 
@@ -383,11 +384,22 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	}
 	templateCache.Add(nc.TagTemplate, t)
 
+	// external-domain-tls and auto-tls
 	if val, ok := data["autoTLS"]; ok {
 		nc.AutoTLS = strings.EqualFold(val, "enabled")
 	}
 	if val, ok := data[AutoTLSKey]; ok {
 		nc.AutoTLS = strings.EqualFold(val, "enabled")
+	}
+	if val, ok := data[ExternalDomainTLSKey]; ok {
+		nc.ExternalDomainTLS = strings.EqualFold(val, "enabled")
+
+		// The new key takes precedence, but we support compatibility
+		// for code that has not updated to the new field yet.
+		nc.AutoTLS = nc.ExternalDomainTLS
+	} else {
+		// backward compatibility: if the new key is not set, use the value from the old key
+		nc.ExternalDomainTLS = nc.AutoTLS
 	}
 
 	var httpProtocol string
@@ -410,52 +422,52 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		return nil, fmt.Errorf("httpProtocol %s in config-network ConfigMap is not supported", data[HTTPProtocolKey])
 	}
 
-	switch strings.ToLower(data[DataplaneTrustKey]) {
-	case "", string(TrustDisabled):
-		// If DataplaneTrus is not set in the config-network, default is already
-		// set to TrustDisabled.
+	switch strings.ToLower(data[KnativeInternalTLSKey]) {
+	case "", string(EncryptionDisabled):
+		// If KnativeInternalTLSKey is not set in the config-network, default is already
+		// set to EncryptionDisabled.
 		if nc.InternalEncryption {
 			// Backward compatibility
-			nc.DataplaneTrust = TrustMinimal
+			nc.KnativeInternalTLS = EncryptionEnabled
 		}
-	case string(TrustMinimal):
-		nc.DataplaneTrust = TrustMinimal
-	case string(TrustEnabled):
-		nc.DataplaneTrust = TrustEnabled
-	case string(TrustMutual):
-		nc.DataplaneTrust = TrustMutual
-	case string(TrustIdentity):
-		nc.DataplaneTrust = TrustIdentity
+	case string(EncryptionEnabled):
+		nc.KnativeInternalTLS = EncryptionEnabled
+
+		// The new key takes precedence, but we support compatibility
+		// for code that has not updated to the new field yet.
+		nc.InternalEncryption = true
 	default:
-		return nil, fmt.Errorf("DataplaneTrust %q in config-network ConfigMap is not supported", data[DataplaneTrustKey])
+		return nil, fmt.Errorf("%s with value: %q in config-network ConfigMap is not supported",
+			KnativeInternalTLSKey, data[KnativeInternalTLSKey])
 	}
 
-	switch strings.ToLower(data[ControlplaneTrustKey]) {
-	case "", string(TrustDisabled):
-		// If ControlplaneTrust is not set in the config-network, default is already
-		// set to TrustDisabled.
-	case string(TrustEnabled):
-		nc.ControlplaneTrust = TrustEnabled
-	case string(TrustMutual):
-		nc.ControlplaneTrust = TrustMutual
+	switch strings.ToLower(data[ClusterLocalDomainTLSKey]) {
+	case "", string(EncryptionDisabled):
+		// If ClusterLocalDomainTLSKey is not set in the config-network, default is already
+		// set to EncryptionDisabled.
+	case string(EncryptionEnabled):
+		nc.ClusterLocalDomainTLS = EncryptionEnabled
 	default:
-		return nil, fmt.Errorf("ControlplaneTrust %q in config-network ConfigMap is not supported", data[ControlplaneTrustKey])
+		return nil, fmt.Errorf("%s with value: %q in config-network ConfigMap is not supported",
+			ClusterLocalDomainTLSKey, data[ClusterLocalDomainTLSKey])
 	}
 
 	return nc, nil
 }
 
-// InternalTLSEnabled returns whether or not InternalEncyrption is enabled.
-// Currently only DataplaneTrust is considered.
+// InternalTLSEnabled returns whether InternalEncryption is enabled or not.
+// Deprecated: please use KnativeInternalTLSEnabled()
 func (c *Config) InternalTLSEnabled() bool {
-	return tlsEnabled(c.DataplaneTrust)
+	return tlsEnabled(c.KnativeInternalTLS)
 }
 
-func tlsEnabled(trust Trust) bool {
-	return trust == TrustMinimal ||
-		trust == TrustEnabled ||
-		trust == TrustMutual ||
-		trust == TrustIdentity
+// KnativeInternalTLSEnabled returns whether KnativeInternalTLS is enabled or not.
+func (c *Config) KnativeInternalTLSEnabled() bool {
+	return tlsEnabled(c.KnativeInternalTLS)
+}
+
+func tlsEnabled(encryptionConfig EncryptionConfig) bool {
+	return encryptionConfig == EncryptionEnabled
 }
 
 // GetDomainTemplate returns the golang Template from the config map

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,12 +145,12 @@ const (
 
 	// InternalEncryptionKey is the name of the configuration whether
 	// internal traffic is encrypted or not.
-	// Deprecated: please use KnativeInternalTLSKey.
+	// Deprecated: please use SystemInternalTLSKey.
 	InternalEncryptionKey = "internal-encryption"
 
-	// KnativeInternalTLSKey is the name of the configuration whether
-	// knative internal traffic is encrypted or not.
-	KnativeInternalTLSKey = "knative-internal-tls"
+	// SystemInternalTLSKey is the name of the configuration whether
+	// traffic between Knative system components is encrypted or not.
+	SystemInternalTLSKey = "system-internal-tls"
 )
 
 // EncryptionConfig indicates the encryption configuration
@@ -294,11 +294,11 @@ type Config struct {
 	DefaultExternalScheme string
 
 	// InternalEncryption specifies whether internal traffic is encrypted or not.
-	// Deprecated: please use KnativeInternalTLSKey instead.
+	// Deprecated: please use SystemInternalTLSKey instead.
 	InternalEncryption bool
 
-	// KnativeInternalTLS specifies whether knative internal traffic is encrypted or not.
-	KnativeInternalTLS EncryptionConfig
+	// SystemInternalTLS specifies whether knative internal traffic is encrypted or not.
+	SystemInternalTLS EncryptionConfig
 
 	// ClusterLocalDomainTLS specifies whether cluster-local traffic is encrypted or not.
 	ClusterLocalDomainTLS EncryptionConfig
@@ -318,7 +318,7 @@ func defaultConfig() *Config {
 		DefaultExternalScheme:         "http",
 		MeshCompatibilityMode:         MeshCompatibilityModeAuto,
 		InternalEncryption:            false,
-		KnativeInternalTLS:            EncryptionDisabled,
+		SystemInternalTLS:             EncryptionDisabled,
 		ClusterLocalDomainTLS:         EncryptionDisabled,
 	}
 }
@@ -422,23 +422,23 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		return nil, fmt.Errorf("httpProtocol %s in config-network ConfigMap is not supported", data[HTTPProtocolKey])
 	}
 
-	switch strings.ToLower(data[KnativeInternalTLSKey]) {
+	switch strings.ToLower(data[SystemInternalTLSKey]) {
 	case "", string(EncryptionDisabled):
-		// If KnativeInternalTLSKey is not set in the config-network, default is already
+		// If SystemInternalTLSKey is not set in the config-network, default is already
 		// set to EncryptionDisabled.
 		if nc.InternalEncryption {
 			// Backward compatibility
-			nc.KnativeInternalTLS = EncryptionEnabled
+			nc.SystemInternalTLS = EncryptionEnabled
 		}
 	case string(EncryptionEnabled):
-		nc.KnativeInternalTLS = EncryptionEnabled
+		nc.SystemInternalTLS = EncryptionEnabled
 
 		// The new key takes precedence, but we support compatibility
 		// for code that has not updated to the new field yet.
 		nc.InternalEncryption = true
 	default:
 		return nil, fmt.Errorf("%s with value: %q in config-network ConfigMap is not supported",
-			KnativeInternalTLSKey, data[KnativeInternalTLSKey])
+			SystemInternalTLSKey, data[SystemInternalTLSKey])
 	}
 
 	switch strings.ToLower(data[ClusterLocalDomainTLSKey]) {
@@ -456,14 +456,14 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 }
 
 // InternalTLSEnabled returns whether InternalEncryption is enabled or not.
-// Deprecated: please use KnativeInternalTLSEnabled()
+// Deprecated: please use SystemInternalTLSEnabled()
 func (c *Config) InternalTLSEnabled() bool {
-	return tlsEnabled(c.KnativeInternalTLS)
+	return tlsEnabled(c.SystemInternalTLS)
 }
 
-// KnativeInternalTLSEnabled returns whether KnativeInternalTLS is enabled or not.
-func (c *Config) KnativeInternalTLSEnabled() bool {
-	return tlsEnabled(c.KnativeInternalTLS)
+// SystemInternalTLSEnabled returns whether SystemInternalTLS is enabled or not.
+func (c *Config) SystemInternalTLSEnabled() bool {
+	return tlsEnabled(c.SystemInternalTLS)
 }
 
 func tlsEnabled(encryptionConfig EncryptionConfig) bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -330,36 +330,36 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.InternalEncryption = true
-			c.KnativeInternalTLS = EncryptionEnabled
+			c.SystemInternalTLS = EncryptionEnabled
 			return c
 		}(),
 	}, {
-		name: "knative-internal-tls with invalid configuration value",
+		name: "system-internal-tls with invalid configuration value",
 		data: map[string]string{
-			KnativeInternalTLSKey: "wrong",
+			SystemInternalTLSKey: "wrong",
 		},
 		wantErr: true,
 	}, {
-		name: "knative-internal-tls with encryption disabled",
+		name: "system-internal-tls with encryption disabled",
 		data: map[string]string{
-			KnativeInternalTLSKey: "disabled",
+			SystemInternalTLSKey: "disabled",
 		},
 		wantErr: false,
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.KnativeInternalTLS = EncryptionDisabled
+			c.SystemInternalTLS = EncryptionDisabled
 			c.InternalEncryption = false
 			return c
 		}(),
 	}, {
-		name: "knative-internal-tls with encryption enabled",
+		name: "system-internal-tls with encryption enabled",
 		data: map[string]string{
-			KnativeInternalTLSKey: "enabled",
+			SystemInternalTLSKey: "enabled",
 		},
 		wantErr: false,
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.KnativeInternalTLS = EncryptionEnabled
+			c.SystemInternalTLS = EncryptionEnabled
 			c.InternalEncryption = true
 			return c
 		}(),
@@ -420,7 +420,7 @@ func TestConfiguration(t *testing.T) {
 
 			// This is defaulted
 			MeshCompatibilityMode: MeshCompatibilityModeAuto,
-			KnativeInternalTLS:    EncryptionDisabled,
+			SystemInternalTLS:     EncryptionDisabled,
 			ClusterLocalDomainTLS: EncryptionDisabled,
 		},
 	}, {
@@ -463,7 +463,7 @@ func TestConfiguration(t *testing.T) {
 
 			// This is defaulted
 			MeshCompatibilityMode: MeshCompatibilityModeAuto,
-			KnativeInternalTLS:    EncryptionDisabled,
+			SystemInternalTLS:     EncryptionDisabled,
 			ClusterLocalDomainTLS: EncryptionDisabled,
 		},
 	}}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -186,7 +186,26 @@ func TestConfiguration(t *testing.T) {
 			DomainTemplateKey: "{{.Name}}.{{.NAmespace}}.{{.Domain}}",
 		},
 	}, {
-		name: "network configuration with Auto TLS enabled",
+		name: "network configuration with external-domain-tls enabled",
+		data: map[string]string{
+			ExternalDomainTLSKey: "enabled",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.AutoTLS = true
+			c.ExternalDomainTLS = true
+			return c
+		}(),
+	}, {
+		name: "network configuration with external-domain-tls disabled",
+		data: map[string]string{
+			ExternalDomainTLSKey: "disabled",
+		},
+		wantErr:    false,
+		wantConfig: defaultConfig(),
+	}, {
+		name: "network configuration with Auto TLS enabled (deprecated)",
 		data: map[string]string{
 			AutoTLSKey: "enabled",
 		},
@@ -194,15 +213,29 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.AutoTLS = true
+			c.ExternalDomainTLS = true
 			return c
 		}(),
 	}, {
-		name: "network configuration with Auto TLS disabled",
+		name: "network configuration with Auto TLS disabled (deprecated)",
 		data: map[string]string{
 			AutoTLSKey: "disabled",
 		},
 		wantErr:    false,
 		wantConfig: defaultConfig(),
+	}, {
+		name: "network configuration with external-domain-tls enabled and Auto TLS disabled",
+		data: map[string]string{
+			ExternalDomainTLSKey: "enabled", // the new key takes precedence
+			AutoTLSKey:           "disabled",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.AutoTLS = true
+			c.ExternalDomainTLS = true
+			return c
+		}(),
 	}, {
 		name: "network configuration with HTTPProtocol disabled",
 		data: map[string]string{
@@ -213,6 +246,7 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.AutoTLS = true
+			c.ExternalDomainTLS = true
 			c.HTTPProtocol = HTTPDisabled
 			return c
 		}(),
@@ -226,6 +260,7 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.AutoTLS = true
+			c.ExternalDomainTLS = true
 			c.HTTPProtocol = HTTPRedirected
 			return c
 		}(),
@@ -277,7 +312,17 @@ func TestConfiguration(t *testing.T) {
 			return c
 		}(),
 	}, {
-		name: "network configuration with activator-ca and activator-san",
+		name: "internal-encryption disabled (deprecated)",
+		data: map[string]string{
+			InternalEncryptionKey: "false",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			return c
+		}(),
+	}, {
+		name: "internal-encryption enabled (deprecated)",
 		data: map[string]string{
 			InternalEncryptionKey: "true",
 		},
@@ -285,41 +330,65 @@ func TestConfiguration(t *testing.T) {
 		wantConfig: func() *Config {
 			c := defaultConfig()
 			c.InternalEncryption = true
-			c.DataplaneTrust = TrustMinimal
+			c.KnativeInternalTLS = EncryptionEnabled
 			return c
 		}(),
 	}, {
-		name: "bad network configuration of the data-plane",
+		name: "knative-internal-tls with invalid configuration value",
 		data: map[string]string{
-			DataplaneTrustKey: "trustLevel",
+			KnativeInternalTLSKey: "wrong",
 		},
 		wantErr: true,
 	}, {
-		name: "network configuration of the data-plane",
+		name: "knative-internal-tls with encryption disabled",
 		data: map[string]string{
-			DataplaneTrustKey: "identity",
+			KnativeInternalTLSKey: "disabled",
 		},
 		wantErr: false,
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.DataplaneTrust = TrustIdentity
+			c.KnativeInternalTLS = EncryptionDisabled
+			c.InternalEncryption = false
 			return c
 		}(),
 	}, {
-		name: "bad network configuration of the control-plane",
+		name: "knative-internal-tls with encryption enabled",
 		data: map[string]string{
-			ControlplaneTrustKey: "trustLevel",
-		},
-		wantErr: true,
-	}, {
-		name: "network configuration of the control-plane",
-		data: map[string]string{
-			ControlplaneTrustKey: "mutual",
+			KnativeInternalTLSKey: "enabled",
 		},
 		wantErr: false,
 		wantConfig: func() *Config {
 			c := defaultConfig()
-			c.ControlplaneTrust = TrustMutual
+			c.KnativeInternalTLS = EncryptionEnabled
+			c.InternalEncryption = true
+			return c
+		}(),
+	}, {
+		name: "cluster-local-domain-tls with invalid configuration value",
+		data: map[string]string{
+			ClusterLocalDomainTLSKey: "wrong",
+		},
+		wantErr: true,
+	}, {
+		name: "cluster-local-domain-tls with encryption disabled",
+		data: map[string]string{
+			ClusterLocalDomainTLSKey: "disabled",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.ClusterLocalDomainTLS = EncryptionDisabled
+			return c
+		}(),
+	}, {
+		name: "cluster-local-domain-tls with encryption enabled",
+		data: map[string]string{
+			ClusterLocalDomainTLSKey: "enabled",
+		},
+		wantErr: false,
+		wantConfig: func() *Config {
+			c := defaultConfig()
+			c.ClusterLocalDomainTLS = EncryptionEnabled
 			return c
 		}(),
 	}, {
@@ -347,11 +416,12 @@ func TestConfiguration(t *testing.T) {
 			AutocreateClusterDomainClaims: true,
 			HTTPProtocol:                  HTTPRedirected,
 			AutoTLS:                       true,
+			ExternalDomainTLS:             true,
 
 			// This is defaulted
 			MeshCompatibilityMode: MeshCompatibilityModeAuto,
-			DataplaneTrust:        TrustDisabled,
-			ControlplaneTrust:     TrustDisabled,
+			KnativeInternalTLS:    EncryptionDisabled,
+			ClusterLocalDomainTLS: EncryptionDisabled,
 		},
 	}, {
 		name: "newer keys take precedence over legacy keys",
@@ -377,8 +447,6 @@ func TestConfiguration(t *testing.T) {
 			AutocreateClusterDomainClaimsKey: "false",
 			HTTPProtocolKey:                  "enabled",
 			AutoTLSKey:                       "disabled",
-			DataplaneTrustKey:                "MiNiMal",
-			ControlplaneTrustKey:             "EnAbLeD",
 		},
 		wantConfig: &Config{
 			DefaultIngressClass:     "7",
@@ -391,11 +459,12 @@ func TestConfiguration(t *testing.T) {
 			AutocreateClusterDomainClaims: false,
 			HTTPProtocol:                  HTTPEnabled,
 			AutoTLS:                       false,
+			ExternalDomainTLS:             false,
 
 			// This is defaulted
 			MeshCompatibilityMode: MeshCompatibilityModeAuto,
-			DataplaneTrust:        TrustMinimal,
-			ControlplaneTrust:     TrustEnabled,
+			KnativeInternalTLS:    EncryptionDisabled,
+			ClusterLocalDomainTLS: EncryptionDisabled,
 		},
 	}}
 


### PR DESCRIPTION
# Changes
- Align the encryption flags according to https://github.com/knative/serving/issues/14368
- Adds reverse compatibility for existing flags
- Drop `dataplane-trust` and `controlplane-trust`

I'd argue that its ok to drop the dataplane-& controlplane-trust flags, as they are clearly marked as ALPHA. IMHO, Introducing backward compatibility for those would make it really unread and unmaintainable. Also we have not implemented this feature and various values of those, so it's basically not possible to be reverse compatible.

/kind cleanup

Partially fixes https://github.com/knative/serving/issues/14368

**Release Note**

```release-note
Renames the flags that control encryption
- `auto-tls` is now named `external-domain-tls`
- `internal-encryption` is now named `system-internal-tls`
- `cluster-local-domain-tls` is introduced as a new alpha state flag to control TLS certificates for cluster-local domains
```

**Docs**
PRs for docs will follow separately in https://github.com/knative/serving/issues/14368
