### PR TITLE
Verify and reconcile new keys' value instead of obsleted keys' in secret

### DIFF
--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -119,7 +119,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		return fmt.Errorf("unknown cert type: %v", r.secretTypeLabelName)
 	}
 
-	cert, _, err := parseAndValidateSecret(secret, caSecret.Data[certificates.SecretCertKey], sans...)
+	cert, _, err := parseAndValidateSecret(secret, caSecret.Data[certificates.CertName], sans...)
 	if err != nil {
 		r.logger.Infof("Secret invalid: %v", err)
 		// Check the secret to reconcile type
@@ -129,7 +129,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		if err != nil {
 			return fmt.Errorf("cannot generate the cert: %w", err)
 		}
-		err = r.commitUpdatedSecret(ctx, secret, keyPair, caSecret.Data[certificates.SecretCertKey])
+		err = r.commitUpdatedSecret(ctx, secret, keyPair, caSecret.Data[certificates.CertName])
 		if err != nil {
 			return err
 		}
@@ -146,21 +146,21 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 
 // All sans provided are required to be lower case
 func parseAndValidateSecret(secret *corev1.Secret, caCert []byte, sans ...string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	certBytes, ok := secret.Data[certificates.SecretCertKey]
+	certBytes, ok := secret.Data[certificates.CertName]
 	if !ok {
-		return nil, nil, fmt.Errorf("missing cert bytes")
+		return nil, nil, fmt.Errorf("missing cert bytes in %q", certificates.CertName)
 	}
-	pkBytes, ok := secret.Data[certificates.SecretPKKey]
+	pkBytes, ok := secret.Data[certificates.PrivateKeyName]
 	if !ok {
-		return nil, nil, fmt.Errorf("missing pk bytes")
+		return nil, nil, fmt.Errorf("missing pk bytes in %q", certificates.PrivateKeyName)
 	}
 	if caCert != nil {
-		ca, ok := secret.Data[certificates.SecretCaCertKey]
+		ca, ok := secret.Data[certificates.CaCertName]
 		if !ok {
-			return nil, nil, fmt.Errorf("missing ca cert bytes")
+			return nil, nil, fmt.Errorf("missing ca cert bytes in %q", certificates.CaCertName)
 		}
 		if !bytes.Equal(ca, caCert) {
-			return nil, nil, fmt.Errorf("ca cert bytes changed")
+			return nil, nil, fmt.Errorf("ca cert bytes changed in %q", certificates.CaCertName)
 		}
 	}
 

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -74,10 +74,10 @@ var _ Interface = (*reconciler)(nil)
 func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) pkgreconciler.Event {
 	// This should not happen, but it happens :) https://github.com/knative/pkg/issues/1891
 	if !r.shouldReconcile(secret) {
-		r.logger.Infof("Skipping reconciling secret %q:%q", secret.Namespace, secret.Name)
+		r.logger.Infof("Skipping reconciling secret %s/%s", secret.Namespace, secret.Name)
 		return nil
 	}
-	r.logger.Infof("Updating secret %q:%q", secret.Namespace, secret.Name)
+	r.logger.Infof("Updating secret %s/%s", secret.Namespace, secret.Name)
 
 	// Reconcile CA secret first
 	caSecret, err := r.secretLister.Secrets(system.Namespace()).Get(r.caSecretName)
@@ -87,7 +87,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		// secret information.
 		return nil
 	} else if err != nil {
-		r.logger.Errorf("Error accessing CA certificate secret %q %q: %v", system.Namespace(), r.caSecretName, err)
+		r.logger.Errorf("Error accessing CA certificate secret %s/%s: %v", system.Namespace(), r.caSecretName, err)
 		return err
 	}
 	caCert, caPk, err := parseAndValidateSecret(caSecret, nil)
@@ -121,7 +121,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 
 	cert, _, err := parseAndValidateSecret(secret, caSecret.Data[certificates.CertName], sans...)
 	if err != nil {
-		r.logger.Infof("Secret invalid: %v", err)
+		r.logger.Infof("Secret %s/%s invalid: %v", secret.Namespace, secret.Name, err)
 		// Check the secret to reconcile type
 
 		var keyPair *certificates.KeyPair


### PR DESCRIPTION
### Changes

https://github.com/knative-extensions/control-protocol/pull/220 introduced new keys and https://github.com/knative/serving/pull/13388 adopted them but the new keys are not verified or reconciled via reconciler.

This patch changes the new keys' values to be reconciled.

### Alternative

Alternatively, we can reconcile both new keys' values and old keys' values but I think we can drop the old keys now in the follow up PR.

### Additional info

Please refer to https://github.com/knative/serving/issues/14407 for the reproducer.

Fix https://github.com/knative/serving/issues/14407
