### PR TITLE
Add additional encryption config flags + labels

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -121,7 +121,7 @@ const (
 	VisibilityLabelKey = PublicGroupName + "/visibility"
 
 	// CertificateTypeLabelKey is the label to indicate the type of Knative certificate
-	// used for Knative Serving encryption functionality.
+	// used for Knative Serving encryption functionality. Corresponding values are defined in config.CertificateType.
 	CertificateTypeLabelKey = PublicGroupName + "/certificate-type"
 )
 

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -119,6 +119,10 @@ const (
 	// already using labels for domain, it probably best to keep this
 	// consistent.
 	VisibilityLabelKey = PublicGroupName + "/visibility"
+
+	// CertificateTypeLabelKey is the label to indicate the type of Knative certificate
+	// used for Knative Serving encryption functionality.
+	CertificateTypeLabelKey = PublicGroupName + "/certificate-type"
 )
 
 // Pseudo-constants

--- a/pkg/apis/networking/v1alpha1/ingress_helpers.go
+++ b/pkg/apis/networking/v1alpha1/ingress_helpers.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// GetIngressTLSForVisibility returns a list of `Spec.TLS` where the `Hosts` field matches
+// to `Spec.Rules.Hosts` and where the Rules have the defined ingress visibility.
+// This method can be used in net-* implementations to select the correct `IngressTLS` entries
+// for cluster-local and cluster-external gateways/listeners.
+func (i *Ingress) GetIngressTLSForVisibility(visibility IngressVisibility) []IngressTLS {
+	ingressTLS := make([]IngressTLS, 0, len(i.Spec.TLS))
+
+	if i.Spec.TLS == nil || len(i.Spec.TLS) == 0 {
+		return ingressTLS
+	}
+
+	for _, r := range i.Spec.Rules {
+		if r.Visibility == visibility {
+			for _, t := range i.Spec.TLS {
+				// Check if hosts slices are equal ignoring the order
+				if cmp.Diff(r.Hosts, t.Hosts, cmpopts.SortSlices(func(a, b string) bool { return a < b })) == "" {
+					ingressTLS = append(ingressTLS, t)
+				}
+			}
+		}
+	}
+
+	return ingressTLS
+}

--- a/pkg/apis/networking/v1alpha1/ingress_helpers_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_helpers_test.go
@@ -135,6 +135,29 @@ func TestGetIngressTLSForVisibility(t *testing.T) {
 			},
 		},
 		want: make([]IngressTLS, 0),
+	}, {
+		name:       "matching entries with additional hosts in TLS block",
+		visibility: IngressVisibilityClusterLocal,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      []string{"expected"},
+						Visibility: IngressVisibilityClusterLocal,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityExternalIP,
+					},
+				},
+				TLS: []IngressTLS{
+					{Hosts: []string{"expected", "additional"}},
+				},
+			},
+		},
+		want: []IngressTLS{
+			{Hosts: []string{"expected", "additional"}},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/networking/v1alpha1/ingress_helpers_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_helpers_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	hosts = []string{"foo", "bar", "foo.bar"}
+)
+
+func TestGetIngressTLSForVisibility(t *testing.T) {
+	tests := []struct {
+		name       string
+		visibility IngressVisibility
+		ingress    *Ingress
+		want       []IngressTLS
+	}{{
+		name:       "no TLS entries",
+		visibility: IngressVisibilityClusterLocal,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      hosts,
+						Visibility: IngressVisibilityClusterLocal,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityExternalIP,
+					},
+				},
+				TLS: make([]IngressTLS, 0),
+			},
+		},
+		want: make([]IngressTLS, 0),
+	}, {
+		name:       "no matching entries",
+		visibility: IngressVisibilityClusterLocal,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      hosts,
+						Visibility: IngressVisibilityClusterLocal,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityExternalIP,
+					},
+				},
+				TLS: []IngressTLS{
+					{Hosts: []string{"something", "else"}},
+				},
+			},
+		},
+		want: make([]IngressTLS, 0),
+	}, {
+		name:       "matching cluster-local entries",
+		visibility: IngressVisibilityClusterLocal,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      hosts,
+						Visibility: IngressVisibilityClusterLocal,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityExternalIP,
+					},
+				},
+				TLS: []IngressTLS{
+					{Hosts: hosts},
+				},
+			},
+		},
+		want: []IngressTLS{{Hosts: hosts}},
+	}, {
+		name:       "matching external-ip entries",
+		visibility: IngressVisibilityExternalIP,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      hosts,
+						Visibility: IngressVisibilityExternalIP,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityClusterLocal,
+					},
+				},
+				TLS: []IngressTLS{
+					{Hosts: hosts},
+				},
+			},
+		},
+		want: []IngressTLS{{Hosts: hosts}},
+	}, {
+		name:       "matching entries with different visibility",
+		visibility: IngressVisibilityClusterLocal,
+		ingress: &Ingress{
+			Spec: IngressSpec{
+				Rules: []IngressRule{
+					{
+						Hosts:      hosts,
+						Visibility: IngressVisibilityExternalIP,
+					},
+					{
+						Hosts:      []string{"other", "entries"},
+						Visibility: IngressVisibilityClusterLocal,
+					},
+				},
+				TLS: []IngressTLS{
+					{Hosts: hosts},
+				},
+			},
+		},
+		want: make([]IngressTLS, 0),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.ingress.GetIngressTLSForVisibility(test.visibility)
+
+			if !cmp.Equal(test.want, got) {
+				t.Errorf("GetIngressTLSForVisibility (-want, +got) = \n%s", cmp.Diff(test.want, got))
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,12 +67,6 @@ const (
 	// Certificate reconciler.
 	CertManagerCertificateClassName = "cert-manager.certificate.networking.knative.dev"
 
-	// ServingInternalCertName is the name of secret contains certificates in serving
-	// system namespace.
-	//
-	// Deprecated: ServingInternalCertName is deprecated. Use ServingRoutingCertName instead.
-	ServingInternalCertName = "knative-serving-certs"
-
 	// ServingRoutingCertName is the name of secret contains certificates for Routing data in serving
 	// system namespace. (Used by Ingress GWs and Activator)
 	ServingRoutingCertName = "routing-serving-certs"
@@ -146,6 +140,20 @@ const (
 	// SystemInternalTLSKey is the name of the configuration whether
 	// traffic between Knative system components is encrypted or not.
 	SystemInternalTLSKey = "system-internal-tls"
+)
+
+// CertificateType indicates the type of Knative Certificate.
+type CertificateType string
+
+const (
+	// CertificateSystemInternal defines a certificate used for `system-internal-tls`.
+	CertificateSystemInternal CertificateType = "system-internal"
+
+	// CertificateClusterLocalDomain defines a certificate used for `cluster-local-domain-tls`.
+	CertificateClusterLocalDomain CertificateType = "cluster-local-domain"
+
+	// CertificateExternalDomain defines a cerificate used for `external-domain-tls`.
+	CertificateExternalDomain CertificateType = "external-domain"
 )
 
 // EncryptionConfig indicates the encryption configuration


### PR DESCRIPTION
# Changes
- In preparation for https://github.com/knative/serving/issues/14216
- Add `CertificateTypeLabelKey` label with values `CertificateType` to indicate different types of a `KnativeCertificate`
- Drop deprecated and now unused `ServingInternalCertName` (checked in all repos in knative + knative-extensions)
- Add helper method `GetIngressTLSForVisibility` to `Ingress` to filter cluster-local and external-ip TLS blocks.

/kind enhancement

Example of `KnativeIngress` with TLS block for cluster-local-domain-tls:

```yaml
apiVersion: networking.internal.knative.dev/v1alpha1
kind: Ingress
metadata:
  name: helloworld
  namespace: default
spec:
  httpOption: Enabled
  rules:
  - hosts:
    - helloworld.default
    - helloworld.default.svc
    - helloworld.default.svc.cluster.local
    http:
      paths:
      - splits:
        - appendHeaders:
            Knative-Serving-Namespace: default
            Knative-Serving-Revision: helloworld-00001
          percent: 100
          serviceName: helloworld-00001
          serviceNamespace: default
          servicePort: 443
    visibility: ClusterLocal
  - hosts:
    - helloworld.default.10.89.0.200.sslip.io
    http:
      paths:
      - splits:
        - appendHeaders:
            Knative-Serving-Namespace: default
            Knative-Serving-Revision: helloworld-00001
          percent: 100
          serviceName: helloworld-00001
          serviceNamespace: default
          servicePort: 443
  tls:
  - hosts:
    - helloworld.default
    - helloworld.default.svc
    - helloworld.default.svc.cluster.local
    secretName: route-ba07ea4e-2548-4632-9187-e615c876cffc-local
    secretNamespace: default
```
