### PR TITLE
Add clotributor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ Check out:
   for more information about the Certificate API spec.
 - [pkg/apis/networking/v1alpha1/certificate_validation.go](pkg/apis/networking/v1alpha1/certificate_validation.go)
   for more information about the validation logic for Certificate API spec.
+
+# Contributing
+
+If you would like to contribute to Knative, take a look at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1)
+for a list of help wanted issues across the project.


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README