### PR TITLE
Replace deprecated `sets` usages with generic version

### DIFF
--- a/pkg/apis/networking/metadata_validation.go
+++ b/pkg/apis/networking/metadata_validation.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	allowedAnnotations = sets.NewString(
+	allowedAnnotations = sets.New[string](
 		IngressClassAnnotationKey,
 		CertificateClassAnnotationKey,
 		DisableAutoTLSAnnotationKey,

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -165,8 +165,8 @@ func parseAndValidateSecret(secret *corev1.Secret, caCert []byte, sans ...string
 		return nil, nil, err
 	}
 
-	sanSet := sets.NewString(sans...)
-	certSet := sets.NewString(cert.DNSNames...)
+	sanSet := sets.New(sans...)
+	certSet := sets.New(cert.DNSNames...)
 	if !sanSet.Equal(certSet) {
 		return nil, nil, fmt.Errorf("unexpected SANs")
 	}

--- a/pkg/certificates/reconciler/reconciler.go
+++ b/pkg/certificates/reconciler/reconciler.go
@@ -289,14 +289,14 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 // updateFinalizersFiltered will update the Finalizers of the resource.
 // TODO: this method could be generic and sync all finalizers. For now it only
 // updates defaultFinalizerName or its override.
-func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Secret, desiredFinalizers sets.String) (*v1.Secret, error) {
+func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource *v1.Secret, desiredFinalizers sets.Set[string]) (*v1.Secret, error) {
 	// Don't modify the informers copy.
 	existing := resource.DeepCopy()
 
 	var finalizers []string
 
 	// If there's nothing to update, just return.
-	existingFinalizers := sets.NewString(existing.Finalizers...)
+	existingFinalizers := sets.New(existing.Finalizers...)
 
 	if desiredFinalizers.Has(r.finalizerName) {
 		if existingFinalizers.Has(r.finalizerName) {
@@ -312,7 +312,7 @@ func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource 
 		}
 		// Remove the finalizer.
 		existingFinalizers.Delete(r.finalizerName)
-		finalizers = existingFinalizers.List()
+		finalizers = sets.List(existingFinalizers)
 	}
 
 	mergePatch := map[string]interface{}{
@@ -346,7 +346,7 @@ func (r *reconcilerImpl) setFinalizerIfFinalizer(ctx context.Context, resource *
 		return resource, nil
 	}
 
-	finalizers := sets.NewString(resource.Finalizers...)
+	finalizers := sets.New(resource.Finalizers...)
 
 	// If this resource is not being deleted, mark the finalizer.
 	if resource.GetDeletionTimestamp().IsZero() {
@@ -365,7 +365,7 @@ func (r *reconcilerImpl) clearFinalizer(ctx context.Context, resource *v1.Secret
 		return resource, nil
 	}
 
-	finalizers := sets.NewString(resource.Finalizers...)
+	finalizers := sets.New(resource.Finalizers...)
 
 	if reconcileEvent != nil {
 		var event *pkgreconciler.ReconcilerEvent

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -73,13 +73,13 @@ func InsertProbe(ing *v1alpha1.Ingress) (string, error) {
 
 // HostsPerVisibility takes an Ingress and a map from visibility levels to a set of string keys,
 // it then returns a map from that key space to the hosts under that visibility.
-func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.IngressVisibility]sets.String) map[string]sets.String {
-	output := make(map[string]sets.String, 2) // We currently have public and internal.
+func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.IngressVisibility]sets.Set[string]) map[string]sets.Set[string] {
+	output := make(map[string]sets.Set[string], 2) // We currently have public and internal.
 	for _, rule := range ing.Spec.Rules {
-		for host := range ExpandedHosts(sets.NewString(rule.Hosts...)) {
+		for host := range ExpandedHosts(sets.New(rule.Hosts...)) {
 			for key := range visibilityToKey[rule.Visibility] {
 				if _, ok := output[key]; !ok {
-					output[key] = make(sets.String, len(rule.Hosts))
+					output[key] = make(sets.Set[string], len(rule.Hosts))
 				}
 				output[key].Insert(host)
 			}
@@ -89,15 +89,15 @@ func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.Ingr
 }
 
 // ExpandedHosts sets up hosts for the short-names for cluster DNS names.
-func ExpandedHosts(hosts sets.String) sets.String {
+func ExpandedHosts(hosts sets.Set[string]) sets.Set[string] {
 	allowedSuffixes := []string{
 		"",
 		"." + network.GetClusterDomainName(),
 		".svc." + network.GetClusterDomainName(),
 	}
 	// Optimistically pre-alloc.
-	expanded := make(sets.String, len(hosts)*len(allowedSuffixes))
-	for _, h := range hosts.List() {
+	expanded := make(sets.Set[string], len(hosts)*len(allowedSuffixes))
+	for _, h := range sets.List(hosts) {
 		for _, suffix := range allowedSuffixes {
 			if th := strings.TrimSuffix(h, suffix); suffix == "" || len(th) < len(h) {
 				if isValidTopLevelDomain(th) {

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -28,57 +28,57 @@ import (
 func TestGetExpandedHosts(t *testing.T) {
 	for _, test := range []struct {
 		name  string
-		hosts sets.String
-		want  sets.String
+		hosts sets.Set[string]
+		want  sets.Set[string]
 	}{{
 		name:  "cluster local service in non-default namespace",
-		hosts: sets.NewString("service.name-space.svc.cluster.local"),
-		want: sets.NewString(
+		hosts: sets.New("service.name-space.svc.cluster.local"),
+		want: sets.New(
 			"service.name-space",
 			"service.name-space.svc",
 			"service.name-space.svc.cluster.local",
 		),
 	}, {
 		name:  "cluster local service in all-numeric namespace",
-		hosts: sets.NewString("service.1234.svc.cluster.local"),
-		want: sets.NewString(
+		hosts: sets.New("service.1234.svc.cluster.local"),
+		want: sets.New(
 			"service.1234.svc",
 			"service.1234.svc.cluster.local",
 		),
 	}, {
 		name:  "funky namespace",
-		hosts: sets.NewString("service.1-1.svc.cluster.local"),
-		want: sets.NewString(
+		hosts: sets.New("service.1-1.svc.cluster.local"),
+		want: sets.New(
 			"service.1-1",
 			"service.1-1.svc",
 			"service.1-1.svc.cluster.local",
 		),
 	}, {
 		name: "cluster local service somehow has a very long tld",
-		hosts: sets.NewString(
+		hosts: sets.New(
 			"service." + strings.Repeat("s", 64) + ".svc.cluster.local",
 		),
-		want: sets.NewString(
+		want: sets.New(
 			"service."+strings.Repeat("s", 64)+".svc",
 			"service."+strings.Repeat("s", 64)+".svc.cluster.local",
 		),
 	}, {
 		name:  "example.com service",
-		hosts: sets.NewString("foo.bar.example.com"),
-		want: sets.NewString(
+		hosts: sets.New("foo.bar.example.com"),
+		want: sets.New(
 			"foo.bar.example.com",
 		),
 	}, {
 		name:  "default.example.com service",
-		hosts: sets.NewString("foo.default.example.com"),
-		want:  sets.NewString("foo.default.example.com"),
+		hosts: sets.New("foo.default.example.com"),
+		want:  sets.New("foo.default.example.com"),
 	}, {
 		name: "mix",
-		hosts: sets.NewString(
+		hosts: sets.New(
 			"foo.default.example.com",
 			"foo.default.svc.cluster.local",
 		),
-		want: sets.NewString(
+		want: sets.New(
 			"foo.default",
 			"foo.default.example.com",
 			"foo.default.svc",
@@ -88,7 +88,7 @@ func TestGetExpandedHosts(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := ExpandedHosts(test.hosts)
 			if !got.Equal(test.want) {
-				t.Errorf("ExpandedHosts diff(-want +got):\n%s", cmp.Diff(got.List(), test.want.List()))
+				t.Errorf("ExpandedHosts diff(-want +got):\n%s", cmp.Diff(sets.List(got), sets.List(test.want)))
 			}
 		})
 	}
@@ -208,8 +208,8 @@ func TestHostsPerVisibility(t *testing.T) {
 	tests := []struct {
 		name    string
 		ingress *v1alpha1.Ingress
-		in      map[v1alpha1.IngressVisibility]sets.String
-		want    map[string]sets.String
+		in      map[v1alpha1.IngressVisibility]sets.Set[string]
+		want    map[string]sets.Set[string]
 	}{{
 		name: "external rule",
 		ingress: &v1alpha1.Ingress{
@@ -235,12 +235,12 @@ func TestHostsPerVisibility(t *testing.T) {
 				}},
 			},
 		},
-		in: map[v1alpha1.IngressVisibility]sets.String{
-			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("foo"),
-			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("bar", "baz"),
+		in: map[v1alpha1.IngressVisibility]sets.Set[string]{
+			v1alpha1.IngressVisibilityExternalIP:   sets.New("foo"),
+			v1alpha1.IngressVisibilityClusterLocal: sets.New("bar", "baz"),
 		},
-		want: map[string]sets.String{
-			"foo": sets.NewString(
+		want: map[string]sets.Set[string]{
+			"foo": sets.New(
 				"example.com",
 				"foo.bar.svc.cluster.local",
 				"foo.bar.svc",
@@ -271,17 +271,17 @@ func TestHostsPerVisibility(t *testing.T) {
 				}},
 			},
 		},
-		in: map[v1alpha1.IngressVisibility]sets.String{
-			v1alpha1.IngressVisibilityExternalIP:   sets.NewString("foo"),
-			v1alpha1.IngressVisibilityClusterLocal: sets.NewString("bar", "baz"),
+		in: map[v1alpha1.IngressVisibility]sets.Set[string]{
+			v1alpha1.IngressVisibilityExternalIP:   sets.New("foo"),
+			v1alpha1.IngressVisibilityClusterLocal: sets.New("bar", "baz"),
 		},
-		want: map[string]sets.String{
-			"bar": sets.NewString(
+		want: map[string]sets.Set[string]{
+			"bar": sets.New(
 				"foo.bar.svc.cluster.local",
 				"foo.bar.svc",
 				"foo.bar",
 			),
-			"baz": sets.NewString(
+			"baz": sets.New(
 				"foo.bar.svc.cluster.local",
 				"foo.bar.svc",
 				"foo.bar",

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -143,14 +143,14 @@ type Manager struct {
 
 	// mu guards keys.
 	mu   sync.Mutex
-	keys sets.String
+	keys sets.Set[string]
 }
 
 // New creates a new Manager, that will invoke the given callback when
 // async probing is finished.
 func New(cb Done, transport http.RoundTripper) *Manager {
 	return &Manager{
-		keys:      sets.NewString(),
+		keys:      sets.New[string](),
 		cb:        cb,
 		transport: transport,
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -96,7 +96,7 @@ type workItem struct {
 
 // ProbeTarget contains the URLs to probes for a set of Pod IPs serving out of the same port.
 type ProbeTarget struct {
-	PodIPs  sets.String
+	PodIPs  sets.Set[string]
 	PodPort string
 	Port    string
 	URLs    []*url.URL

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -109,7 +109,7 @@ func TestProbeAllHosts(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs:  sets.NewString(hostname),
+			PodIPs:  sets.New(hostname),
 			PodPort: strconv.Itoa(port),
 			URLs:    []*url.URL{tsURL},
 		}},
@@ -233,7 +233,7 @@ func TestProbeLifecycle(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs:  sets.NewString(hostname),
+			PodIPs:  sets.New(hostname),
 			PodPort: strconv.Itoa(port),
 			URLs:    []*url.URL{tsURL},
 		}},
@@ -387,7 +387,7 @@ func TestCancelPodProbing(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs:  sets.NewString(hostname),
+			PodIPs:  sets.New(hostname),
 			PodPort: strconv.Itoa(port),
 			URLs:    []*url.URL{tsURL},
 		}},
@@ -530,7 +530,7 @@ func TestPartialPodCancellation(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs:  sets.NewString(pods[0].Status.PodIP, pods[1].Status.PodIP),
+			PodIPs:  sets.New(pods[0].Status.PodIP, pods[1].Status.PodIP),
 			PodPort: strconv.Itoa(port),
 			URLs:    []*url.URL{tsURL},
 		}},
@@ -604,7 +604,7 @@ func TestCancelIngressProbing(t *testing.T) {
 	prober := NewProber(
 		zaptest.NewLogger(t).Sugar(),
 		fakeProbeTargetLister{{
-			PodIPs:  sets.NewString(hostname),
+			PodIPs:  sets.New(hostname),
 			PodPort: strconv.Itoa(port),
 			URLs:    []*url.URL{tsURL},
 		}},

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -134,7 +134,7 @@ func WaitForCertificateState(ctx context.Context, client *test.NetworkingClients
 func VerifyChallenges(ctx context.Context, t *testing.T, client *test.Clients, cert *v1alpha1.Certificate) {
 	t.Helper()
 
-	certDomains := sets.NewString(cert.Spec.DNSNames...)
+	certDomains := sets.New(cert.Spec.DNSNames...)
 
 	for _, challenge := range cert.Status.HTTP01Challenges {
 		if challenge.ServiceName == "" {

--- a/test/conformance/ingress/grpc.go
+++ b/test/conformance/ingress/grpc.go
@@ -102,7 +102,7 @@ func TestGRPCSplit(t *testing.T) {
 	greenName, greenPort, _ := CreateGRPCService(ctx, t, clients, suffixGreen)
 
 	// The suffixes we expect to see.
-	want := sets.NewString(suffixBlue, suffixGreen)
+	want := sets.New(suffixBlue, suffixGreen)
 
 	// Create a simple Ingress over the Service.
 	name := test.ObjectNameForTest(t)
@@ -150,7 +150,7 @@ func TestGRPCSplit(t *testing.T) {
 	defer cancel()
 
 	const maxRequests = 100
-	got := sets.NewString()
+	got := sets.New[string]()
 	for i := 0; i < maxRequests; i++ {
 		stream, err := pc.PingStream(ctx)
 		if err != nil {

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -283,7 +283,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 	)
 
 	backends := make([]v1alpha1.IngressBackendSplit, 0, splits)
-	names := make(sets.String, splits)
+	names := make(sets.Set[string], splits)
 	for i := 0; i < splits; i++ {
 		name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
 		backends = append(backends, v1alpha1.IngressBackendSplit{
@@ -322,7 +322,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 		// Make enough requests that the likelihood of us seeing each variation is high,
 		// but don't check the distribution of requests, as that isn't the point of this
 		// particular test.
-		seen := make(sets.String, len(names))
+		seen := make(sets.Set[string], len(names))
 		for i := 0; i < maxRequests; i++ {
 			ri := RuntimeRequest(ctx, t, client, "http://"+name+".example.com")
 			if ri == nil {
@@ -345,7 +345,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 		// Make enough requests that the likelihood of us seeing each variation is high,
 		// but don't check the distribution of requests, as that isn't the point of this
 		// particular test.
-		seen := make(sets.String, len(names))
+		seen := make(sets.Set[string], len(names))
 		for i := 0; i < maxRequests; i++ {
 			ri := RuntimeRequest(ctx, t, client, "http://"+name+".example.com", func(req *http.Request) {
 				// Specify a value for the header to verify that implementations

--- a/test/conformance/ingress/path.go
+++ b/test/conformance/ingress/path.go
@@ -209,7 +209,7 @@ func TestPathAndPercentageSplit(t *testing.T) {
 		totalHalf = total / 2
 		tolerance = total * 0.15
 	)
-	wantKeys := sets.NewString(fooName, barName)
+	wantKeys := sets.New(fooName, barName)
 	resultCh := make(chan string, total)
 
 	var g errgroup.Group

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -1104,7 +1104,7 @@ type ResponseExpectation func(response *http.Response) error
 
 func RuntimeRequest(ctx context.Context, t *testing.T, client *http.Client, url string, opts ...RequestOption) *types.RuntimeInfo {
 	return RuntimeRequestWithExpectations(ctx, t, client, url,
-		[]ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusOK))},
+		[]ResponseExpectation{StatusCodeExpectation(sets.New(http.StatusOK))},
 		false,
 		opts...)
 }
@@ -1173,7 +1173,7 @@ func DumpResponse(_ context.Context, t *testing.T, resp *http.Response) {
 	t.Log(string(b))
 }
 
-func StatusCodeExpectation(statusCodes sets.Int) ResponseExpectation {
+func StatusCodeExpectation(statusCodes sets.Set[int]) ResponseExpectation {
 	return func(response *http.Response) error {
 		if !statusCodes.Has(response.StatusCode) {
 			return fmt.Errorf("got unexpected status: %d, expected %v", response.StatusCode, statusCodes)

--- a/test/conformance/ingress/visibility.go
+++ b/test/conformance/ingress/visibility.go
@@ -65,7 +65,7 @@ func TestVisibility(t *testing.T) {
 
 	// Ensure the service is not publicly accessible
 	for _, privateHostName := range privateHostNames {
-		RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+		RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.New(http.StatusNotFound))}, true)
 	}
 
 	for name := range privateHostNames {
@@ -165,7 +165,7 @@ func TestVisibilitySplit(t *testing.T) {
 	})
 
 	// Ensure we can't connect to the private resources
-	RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+	RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.New(http.StatusNotFound))}, true)
 
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, _ := CreateProxyService(ctx, t, clients, privateHostName, loadbalancerAddress)
@@ -328,7 +328,7 @@ func TestVisibilityPath(t *testing.T) {
 
 	// Ensure we can't connect to the private resources
 	for _, path := range []string{"", "/foo", "/bar", "/baz"} {
-		RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName+path, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+		RuntimeRequestWithExpectations(ctx, t, client, "http://"+privateHostName+path, []ResponseExpectation{StatusCodeExpectation(sets.New(http.StatusNotFound))}, true)
 	}
 
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal

--- a/test/conformance/ingress/websocket.go
+++ b/test/conformance/ingress/websocket.go
@@ -93,7 +93,7 @@ func TestWebsocketSplit(t *testing.T) {
 	greenName, greenPort, _ := CreateWebsocketService(ctx, t, clients, suffixGreen)
 
 	// The suffixes we expect to see.
-	want := sets.NewString(suffixBlue, suffixGreen)
+	want := sets.New(suffixBlue, suffixGreen)
 
 	// Create a simple Ingress over the Service.
 	name := test.ObjectNameForTest(t)
@@ -132,7 +132,7 @@ func TestWebsocketSplit(t *testing.T) {
 	u := url.URL{Scheme: "ws", Host: domain, Path: "/"}
 
 	const maxRequests = 100
-	got := sets.NewString()
+	got := sets.New[string]()
 	for i := 0; i < maxRequests; i++ {
 		conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
 		if err != nil {
@@ -157,7 +157,7 @@ func TestWebsocketSplit(t *testing.T) {
 	}
 
 	// Us getting here means we haven't seen splits.
-	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(want.List(), got.List()))
+	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(sets.List(want), sets.List(got)))
 }
 
 func findWebsocketSuffix(t *testing.T, conn *websocket.Conn) string {


### PR DESCRIPTION
# Changes
- Follow-up for https://github.com/knative/pkg/pull/2915
- Replaces all deprecated usages of `sets` with new generic versions

/kind cleanup

Partially https://github.com/knative/serving/issues/14692
