### PR TITLE
Update grpc/h2c conformance test 

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -555,9 +555,10 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 		Spec: corev1.ServiceSpec{
 			Type: "ClusterIP",
 			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
-				Port:       int32(port),
-				TargetPort: intstr.FromInt(containerPort),
+				Name:        networking.ServicePortNameH2C,
+				Port:        int32(port),
+				TargetPort:  intstr.FromInt(containerPort),
+				AppProtocol: ptr.String("kubernetes.io/h2c"),
 			}},
 			Selector: map[string]string{
 				"test-pod": name,


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/14569

As part of the Gateway API work backend protocols can be
hinted using a Service's `appProtocol` attribute.

This sets the attribute on the h2c/grpc test

See the GEP: https://gateway-api.sigs.k8s.io/geps/gep-1911/