### PR TITLE
Exclude test folder from code coverage calculation

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -15,6 +15,7 @@ ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "**/*.pb.go" # Ignore proto-generated files.
   - "hack"
+  - "test"
   - "pkg/client"
   - "third_party"
   - "vendor"


### PR DESCRIPTION
Looking at the code coverage report it's low (20%) because of the lack of coverage in the `test` folder. 

GIven the `test` subfolder contains our conformance tests (but as a library) including that in the code coverage doesn't really make sense.

This PR updates the codecov file to exclude that folder.