### PR TITLE
add the h2c app protocol value for the HTTP2 test

### DIFF
--- a/test/conformance/ingress/basic.go
+++ b/test/conformance/ingress/basic.go
@@ -61,7 +61,10 @@ func TestBasicsHTTP2(t *testing.T) {
 	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
 
-	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameH2C)
+	name, port, _ := CreateRuntimeService(ctx, t, clients,
+		networking.ServicePortNameH2C,
+		networking.AppProtocolH2C,
+	)
 
 	// Create a simple Ingress over the Service.
 	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -92,7 +92,7 @@ func (ua *uaRoundTripper) RoundTrip(rq *http.Request) (*http.Response, error) {
 // specified with the given portName.  It returns the service name, the port on
 // which the service is listening, and a "cancel" function to clean up the
 // created resources.
-func CreateRuntimeService(ctx context.Context, t *testing.T, clients *test.Clients, portName string) (string, int, context.CancelFunc) {
+func CreateRuntimeService(ctx context.Context, t *testing.T, clients *test.Clients, portName string, appProtocol ...string) (string, int, context.CancelFunc) {
 	t.Helper()
 	name := test.ObjectNameForTest(t)
 
@@ -169,6 +169,10 @@ func CreateRuntimeService(ctx context.Context, t *testing.T, clients *test.Clien
 				"test-pod": name,
 			},
 		},
+	}
+
+	if appProtocol != "" {
+		svc.Spec.Ports[0].AppProtocol = &appProtocol
 	}
 
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
@@ -558,7 +562,7 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 				Name:        networking.ServicePortNameH2C,
 				Port:        int32(port),
 				TargetPort:  intstr.FromInt(containerPort),
-				AppProtocol: ptr.String("kubernetes.io/h2c"),
+				AppProtocol: ptr.String(networking.AppProtocolH2C),
 			}},
 			Selector: map[string]string{
 				"test-pod": name,

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -171,8 +171,8 @@ func CreateRuntimeService(ctx context.Context, t *testing.T, clients *test.Clien
 		},
 	}
 
-	if appProtocol != "" {
-		svc.Spec.Ports[0].AppProtocol = &appProtocol
+	if len(appProtocol) > 0 {
+		svc.Spec.Ports[0].AppProtocol = ptr.String(appProtocol[0])
 	}
 
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)


### PR DESCRIPTION
I missed setting the h2c appProtocol label for the HTTP2 test in https://github.com/knative/networking/pull/932

/assign @izabelacg 