### PR TITLE
this fixes the probe handler to reflect that it doesn't care about the path

### DIFF
--- a/test/test_images/runtime/handlers/handler.go
+++ b/test/test_images/runtime/handlers/handler.go
@@ -24,16 +24,13 @@ import (
 	"strings"
 
 	nethttp "knative.dev/networking/pkg/http"
-	"knative.dev/networking/pkg/http/probe"
 	"knative.dev/pkg/network"
 )
 
 // InitHandlers initializes all handlers.
 func InitHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/", withHeaders(withRequestLog(runtimeHandler)))
-
-	h := probe.NewHandler(withRequestLog(withKubeletProbeHeaderCheck))
-	mux.HandleFunc(nethttp.HealthCheckPath, h.ServeHTTP)
+	mux.HandleFunc(nethttp.HealthCheckPath, withRequestLog(withKubeletProbeHeaderCheck))
 }
 
 // withRequestLog logs each request before handling it.

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 
+	"knative.dev/networking/pkg/http/probe"
 	"knative.dev/networking/test"
 	"knative.dev/networking/test/test_images/runtime/handlers"
 )
@@ -48,11 +49,13 @@ func main() {
 	mux := http.NewServeMux()
 	handlers.InitHandlers(mux)
 
+	h := probe.NewHandler(mux)
+
 	if cert, key := os.Getenv("CERT"), os.Getenv("KEY"); cert != "" && key != "" {
 		log.Print("Server starting on port with TLS ", port)
-		test.ListenAndServeTLSGracefullyWithHandler(cert, key, ":"+port, mux)
+		test.ListenAndServeTLSGracefullyWithHandler(cert, key, ":"+port, h)
 	} else {
 		log.Print("Server starting on port ", port)
-		test.ListenAndServeGracefullyWithHandler(":"+port, mux)
+		test.ListenAndServeGracefullyWithHandler(":"+port, h)
 	}
 }


### PR DESCRIPTION
While working on https://github.com/knative-extensions/net-gateway-api/issues/18

I discovered the runtime image in this repository doesn't behave like the queue proxy. The probe handler should work with _any_ URL path but this image it only works when the path is `/healthz`

/assign @izabelacg 