### PR TITLE
Remove requestDelay flag for tests

### DIFF
--- a/test/conformance/ingress/timeout.go
+++ b/test/conformance/ingress/timeout.go
@@ -86,13 +86,6 @@ func TestTimeout(t *testing.T) {
 
 func checkTimeout(ctx context.Context, t *testing.T, client *http.Client, name string, code int, initial time.Duration, timeout time.Duration) {
 	t.Helper()
-	if test.NetworkingFlags.RequestDelay < 0 {
-		t.Error("Error creating Request:", fmt.Errorf("request delay value must be greater than or equal to 0, receieved %d", test.NetworkingFlags.RequestDelay))
-	}
-	if test.NetworkingFlags.RequestDelay > 0 {
-		t.Logf("delay of %d before doing the request", test.NetworkingFlags.RequestDelay)
-		time.Sleep(time.Duration(test.NetworkingFlags.RequestDelay) * time.Second)
-	}
 
 	resp, err := client.Get(fmt.Sprintf("http://%s.%s?initialTimeout=%d&timeout=%d",
 		name, test.NetworkingFlags.ServiceDomain, initial.Milliseconds(), timeout.Milliseconds()))

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -1135,15 +1135,6 @@ func RuntimeRequestWithExpectations(ctx context.Context, t *testing.T, client *h
 	opts ...RequestOption) *types.RuntimeInfo {
 	t.Helper()
 
-	if test.NetworkingFlags.RequestDelay < 0 {
-		t.Error("Error creating Request:", fmt.Errorf("request delay value must be greater than or equal to 0, receieved %d", test.NetworkingFlags.RequestDelay))
-		return nil
-	}
-	if test.NetworkingFlags.RequestDelay > 0 {
-		t.Logf("delay of %d before doing the request", test.NetworkingFlags.RequestDelay)
-		time.Sleep(time.Duration(test.NetworkingFlags.RequestDelay) * time.Second)
-	}
-
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		t.Error("Error creating Request:", err)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -45,7 +45,6 @@ type NetworkingEnvironmentFlags struct {
 	SkipTests           string // Indicates the test names we want to skip in alpha or beta features.
 	ClusterSuffix       string // Specifies the cluster DNS suffix to be used in tests.
 	ServiceDomain       string // Specifies the domain to use when creating the test services.
-	RequestDelay        int    // Specifies delay in Seconds before the client tries to dial the service
 }
 
 func initializeNetworkingFlags() *NetworkingEnvironmentFlags {
@@ -106,11 +105,6 @@ func initializeNetworkingFlags() *NetworkingEnvironmentFlags {
 		"service-domain",
 		"example.com",
 		"Set this flag to the domain to be used in tests.")
-
-	flag.IntVar(&f.RequestDelay,
-		"request-delay",
-		0,
-		"Set this flag to the number of seconds to wait before calling the service.")
 
 	return &f
 }


### PR DESCRIPTION
# Changes

- :broom: Remove test flag `requestDelay` as this can cause dispatch test to run for an extremely long time.

/kind cleanup