### PR TITLE
drop unnecessary external name svc

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -256,6 +256,9 @@ func CreateProxyService(ctx context.Context, t *testing.T, clients *test.Clients
 					Name:  "TARGET_HOST",
 					Value: target,
 				}, {
+					Name:  "GATEWAY_HOST",
+					Value: gatewayDomain,
+				}, {
 					Name:  "PORT",
 					Value: strconv.Itoa(containerPort),
 				}},
@@ -306,13 +309,7 @@ func CreateProxyService(ctx context.Context, t *testing.T, clients *test.Clients
 		},
 	}
 	proxyServiceCancel := createPodAndService(ctx, t, clients, pod, svc)
-
-	externalNameServiceCancel := createExternalNameService(ctx, t, clients, target, gatewayDomain)
-
-	return name, port, func() {
-		externalNameServiceCancel()
-		proxyServiceCancel()
-	}
+	return name, port, proxyServiceCancel
 }
 
 // CreateTimeoutService creates a Kubernetes service that will respond to the protocol


### PR DESCRIPTION
When debugging the visibility split issues in https://github.com/knative-extensions/net-contour/pull/1149 I realize we don't need the extra ExternalName K8s Service.

It was being used to supply a DNS entry that would map a host name to the contour internal envoy service. 

As an alternative we can add a `GATEWAY_HOST` env var that will configure the conformance httpproxy app to just dial the envoy service directly.