### PR TITLE
Fix idle connection leak in prober

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -385,6 +385,8 @@ func (m *Prober) processWorkItem() bool {
 		// Therefore, we can safely ignore any TLS certificate validation.
 		InsecureSkipVerify: true,
 	}
+	// Disable keep-alives to prevent connection leak since a new transport is created per work item.
+	transport.DisableKeepAlives = true
 	transport.DialContext = func(ctx context.Context, network, addr string) (conn net.Conn, e error) {
 		// Requests with the IP as hostname and the Host header set do no pass client-side validation
 		// because the HTTP client validates that the hostname (not the Host header) matches the server
@@ -421,6 +423,7 @@ func (m *Prober) processWorkItem() bool {
 		item.logger.Errorf("Probing of %s failed, IP: %s:%s, ready: %t, error: %v (depth: %d)",
 			item.url, item.podIP, item.podPort, ok, err, m.workQueue.Len())
 	} else {
+		m.workQueue.Forget(obj)
 		m.onProbingSuccess(item.ingressState, item.podState)
 	}
 	return true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix memory leak in prober with reusable transport
 
Per soak tests run on our Serverless distro with serving + net-kourier @maschmid observed a liner memory increase over time that may lead to OOM. It was traced down to idle connection pool steadily increasing.

>In a serving-focused soak test with re-creating ksvcs, keeping around stable ~100 ksvcs on the cluster, net-kourier-controller with increased memory limit restarted 2 times on OOM during a 12h soak run.


/cc @maschmid @linkvt @dprotaso 